### PR TITLE
Predict for time series

### DIFF
--- a/cases/multi_ts_level_forecasting.py
+++ b/cases/multi_ts_level_forecasting.py
@@ -35,20 +35,6 @@ def prepare_data(forecast_length, is_multi_ts):
     return train_data, test_data, task
 
 
-def visualize_result(train, test, target, forecast, is_multi_ts):
-    if is_multi_ts:
-        history = np.ravel(train.target[:, 0])
-    else:
-        history = np.ravel(train.target)
-    plt.plot(np.ravel(test.idx), target, label='test')
-    plt.plot(np.ravel(train.idx), history, label='history')
-    plt.plot(np.ravel(test.idx), forecast, label='prediction_after_tuning')
-    plt.xlabel('Time step')
-    plt.ylabel('Sea level')
-    plt.legend()
-    plt.show()
-
-
 def run_multi_ts_forecast(forecast_length, is_multi_ts):
     """
     Function for run experiment with use multi_ts data type (is_multi_ts=True) for train set extension
@@ -78,7 +64,7 @@ def run_multi_ts_forecast(forecast_length, is_multi_ts):
     target = np.ravel(test_data.target)
 
     # visualize results
-    visualize_result(train_data, test_data, target, forecast, is_multi_ts)
+    model.plot_prediction()
 
     print(f'MAE: {mean_absolute_error(target, forecast)}')
     print(f'RMSE: {mean_squared_error(target, forecast)}')

--- a/examples/simple/time_series_forecasting/api_forecasting.py
+++ b/examples/simple/time_series_forecasting/api_forecasting.py
@@ -50,23 +50,27 @@ def run_ts_forecasting_example(dataset='australia', horizon: int = 30, validatio
     # run AutoML model design in the same way
     pipeline = model.fit(train_data)
 
-    # use model to obtain in-sample forecast
-    model.predict(test_data)
-    print(model.get_metrics(metric_names=['rmse', 'mae', 'mape'], target=test_data.target))
+    # use model to obtain two-step in-sample forecast
+    forecast = model.predict(test_data, in_sample=True)
+    print('Metrics for two-step in-sample forecast: ',
+          model.get_metrics(metric_names=['rmse', 'mae', 'mape'], in_sample=True))
 
     # plot forecasting result
     if visualization:
         pipeline.show()
-        model.plot_prediction()
+        model.plot_prediction(in_sample=True)
 
     # use model to obtain one-step forecast
     train_data, test_data = train_test_data_setup(train_input)
     forecast = model.predict(test_data)
+    print('Metrics for one-step forecast: ',
+          model.get_metrics(metric_names=['rmse', 'mae', 'mape']))
     if visualization:
         model.plot_prediction()
 
     # use model to obtain two-step out-of-sample forecast
     forecast = model.forecast(test_data, horizon=20)
+    # we can not calculate metrics because we do not have enough future values
     if visualization:
         model.plot_prediction()
 

--- a/examples/simple/time_series_forecasting/api_forecasting.py
+++ b/examples/simple/time_series_forecasting/api_forecasting.py
@@ -1,6 +1,5 @@
 import logging
 
-import numpy as np
 import pandas as pd
 
 from fedot.api.main import Fedot

--- a/examples/simple/time_series_forecasting/api_forecasting.py
+++ b/examples/simple/time_series_forecasting/api_forecasting.py
@@ -38,7 +38,7 @@ def run_ts_forecasting_example(dataset='australia', horizon: int = 30, validatio
                             target=time_series,
                             task=task,
                             data_type=DataTypesEnum.ts)
-    train_data, test_data = train_test_data_setup(train_input)
+    train_data, test_data = train_test_data_setup(train_input, validation_blocks=validation_blocks)
 
     # init model for the time series forecasting
     model = Fedot(problem='ts_forecasting',
@@ -51,7 +51,7 @@ def run_ts_forecasting_example(dataset='australia', horizon: int = 30, validatio
     pipeline = model.fit(train_data)
 
     # use model to obtain in-sample forecast
-    forecast = model.predict(test_data)
+    model.predict(test_data)
     print(model.get_metrics(metric_names=['rmse', 'mae', 'mape'], target=test_data.target))
 
     # plot forecasting result

--- a/examples/simple/time_series_forecasting/api_forecasting.py
+++ b/examples/simple/time_series_forecasting/api_forecasting.py
@@ -50,7 +50,7 @@ def run_ts_forecasting_example(dataset='australia', horizon: int = 30, validatio
     pipeline = model.fit(train_data)
 
     # use model to obtain two-step in-sample forecast
-    forecast = model.predict(test_data, in_sample=True)
+    in_sample_forecast = model.predict(test_data, in_sample=True)
     print('Metrics for two-step in-sample forecast: ',
           model.get_metrics(metric_names=['rmse', 'mae', 'mape'], in_sample=True))
 
@@ -61,19 +61,19 @@ def run_ts_forecasting_example(dataset='australia', horizon: int = 30, validatio
 
     # use model to obtain one-step forecast
     train_data, test_data = train_test_data_setup(train_input)
-    forecast = model.predict(test_data)
+    simple_forecast = model.forecast(test_data)
     print('Metrics for one-step forecast: ',
           model.get_metrics(metric_names=['rmse', 'mae', 'mape']))
     if visualization:
         model.plot_prediction()
 
     # use model to obtain two-step out-of-sample forecast
-    forecast = model.forecast(test_data, horizon=20)
+    out_of_sample_forecast = model.forecast(test_data, horizon=20)
     # we can not calculate metrics because we do not have enough future values
     if visualization:
         model.plot_prediction()
 
-    return forecast
+    return in_sample_forecast, simple_forecast, out_of_sample_forecast
 
 
 if __name__ == '__main__':

--- a/examples/simple/time_series_forecasting/api_forecasting.py
+++ b/examples/simple/time_series_forecasting/api_forecasting.py
@@ -50,13 +50,24 @@ def run_ts_forecasting_example(dataset='australia', horizon: int = 30, validatio
     # run AutoML model design in the same way
     pipeline = model.fit(train_data)
 
-    # use model to obtain forecast
+    # use model to obtain in-sample forecast
     forecast = model.predict(test_data)
     print(model.get_metrics(metric_names=['rmse', 'mae', 'mape'], target=test_data.target))
 
     # plot forecasting result
     if visualization:
         pipeline.show()
+        model.plot_prediction()
+
+    # use model to obtain one-step forecast
+    train_data, test_data = train_test_data_setup(train_input)
+    forecast = model.predict(test_data)
+    if visualization:
+        model.plot_prediction()
+
+    # use model to obtain two-step out-of-sample forecast
+    forecast = model.forecast(test_data, horizon=20)
+    if visualization:
         model.plot_prediction()
 
     return forecast

--- a/examples/simple/time_series_forecasting/api_forecasting.py
+++ b/examples/simple/time_series_forecasting/api_forecasting.py
@@ -50,14 +50,14 @@ def run_ts_forecasting_example(dataset='australia', horizon: int = 30, validatio
     pipeline = model.fit(train_data)
 
     # use model to obtain two-step in-sample forecast
-    in_sample_forecast = model.predict(test_data, in_sample=True)
+    in_sample_forecast = model.predict(test_data)
     print('Metrics for two-step in-sample forecast: ',
-          model.get_metrics(metric_names=['rmse', 'mae', 'mape'], in_sample=True))
+          model.get_metrics(metric_names=['rmse', 'mae', 'mape']))
 
     # plot forecasting result
     if visualization:
         pipeline.show()
-        model.plot_prediction(in_sample=True)
+        model.plot_prediction()
 
     # use model to obtain one-step forecast
     train_data, test_data = train_test_data_setup(train_input)

--- a/fedot/api/fedot_cli.py
+++ b/fedot/api/fedot_cli.py
@@ -73,7 +73,7 @@ def run_fedot(parameters, main_params, fit_params, save_predictions=True):
     print("\nFitting start...")
     model.fit(**fit_params)
     print("\nPrediction start...")
-    prediction = model.predict(features=getattr(parameters, 'test'), save_predictions=save_predictions)
+    prediction = model.predict(features=getattr(parameters, 'test'), in_sample=False, save_predictions=save_predictions)
     print(f"\nPrediction saved at {os.getcwd()}\\predictions.csv")
     return prediction
 

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -132,7 +132,7 @@ class Fedot:
 
         self.target: Optional[TargetType] = None
         self.prediction: Optional[OutputData] = None
-        self.prediction_is_in_sample = True
+        self._is_in_sample_prediction = True
         self.train_data: Optional[InputData] = None
         self.test_data: Optional[InputData] = None
 
@@ -221,12 +221,12 @@ class Fedot:
             raise ValueError(NOT_FITTED_ERR_MSG)
 
         self.test_data = self.data_processor.define_data(target=self.target, features=features, is_predict=True)
-        self.prediction_is_in_sample = in_sample
+        self._is_in_sample_prediction = in_sample
         validation_blocks = validation_blocks or self.params.api_params.get('validation_blocks')
 
         self.prediction = self.data_processor.define_predictions(current_pipeline=self.current_pipeline,
                                                                  test_data=self.test_data,
-                                                                 in_sample=self.prediction_is_in_sample,
+                                                                 in_sample=self._is_in_sample_prediction,
                                                                  validation_blocks=validation_blocks)
 
         if save_predictions:
@@ -294,7 +294,7 @@ class Fedot:
                                                          is_predict=True)
         predict = out_of_sample_ts_forecast(self.current_pipeline, self.test_data, horizon)
         self.prediction = convert_forecast_to_output(self.test_data, predict)
-        self.prediction_is_in_sample = False
+        self._is_in_sample_prediction = False
         if save_predictions:
             self.save_predict(self.prediction)
         return self.prediction.predict
@@ -337,7 +337,7 @@ class Fedot:
         """
         if self.prediction is not None:
             if self.params.api_params['task'].task_type == TaskTypesEnum.ts_forecasting:
-                in_sample = in_sample or self.prediction_is_in_sample
+                in_sample = in_sample or self._is_in_sample_prediction
                 plot_forecast(self.test_data, self.prediction, in_sample, target)
             elif self.params.api_params['task'].task_type == TaskTypesEnum.regression:
                 plot_biplot(self.prediction)
@@ -398,8 +398,8 @@ class Fedot:
                     prediction.predict = self.predict_proba(self.test_data)
                 else:
                     if in_sample is not None:
-                        self.prediction_is_in_sample = in_sample
-                    prediction.predict = self.predict(self.test_data, in_sample=self.prediction_is_in_sample,
+                        self._is_in_sample_prediction = in_sample
+                    prediction.predict = self.predict(self.test_data, in_sample=self._is_in_sample_prediction,
                                                       validation_blocks=validation_blocks)
                 real = deepcopy(self.test_data)
 

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -270,7 +270,9 @@ class Fedot:
 
         forecast_length = self.train_data.task.task_params.forecast_length
         horizon = horizon if horizon is not None else forecast_length
-        pre_history = pre_history if pre_history is not None else self.train_data
+        if pre_history is None:
+            pre_history = self.train_data
+            pre_history.target = None
         self.test_data = self.data_processor.define_data(target=self.target,
                                                          features=pre_history,
                                                          is_predict=True)

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -200,16 +200,17 @@ class Fedot:
                 validation_blocks: Optional[int] = None) -> np.ndarray:
         """Predicts new target using already fitted model.
 
-        For time-series performs in-sample forecast if length of idx of InputData is bigger than forecast length.
+        For time-series performs forecast with depth ``forecast_length`` if ``in_sample=False``.
+        If ``in_sample=True`` performs in-sample forecast using features as sample.
 
         Args:
             features: the array with features of test data
             save_predictions: if ``True`` - save predictions as csv-file in working directory
             in_sample: used while time-series prediction. If ``in_sample=True`` performs in-sample forecast using
-            features with number if iterations specified in ``validation_blocks``.
+                features with number if iterations specified in ``validation_blocks``.
             validation_blocks: number of validation blocks for in-sample forecast.
-            If ``validation_blocks = None`` uses number of validation blocks set during model initialization
-            (default is 2).
+                If ``validation_blocks = None`` uses number of validation blocks set during model initialization
+                (default is 2).
 
 
         Returns:
@@ -357,11 +358,11 @@ class Fedot:
         Args:
             target: the array with target values of test data
             metric_names: the names of required metrics
-            in_sample: used for time-series forecasting. If True prediction will be obtained as
-            ``.predict(..., in_sample=True)``.
+            in_sample: used for time-series forecasting.
+                If True prediction will be obtained as ``.predict(..., in_sample=True)``.
             validation_blocks: number of validation blocks for in-sample forecast.
-            If ``validation_blocks = None`` uses number of validation blocks set during model initialization
-            (default is 2).
+                If ``validation_blocks = None`` uses number of validation blocks set during model initialization
+                (default is 2).
 
         Returns:
             the values of quality metrics

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -132,6 +132,7 @@ class Fedot:
 
         self.target: Optional[TargetType] = None
         self.prediction: Optional[OutputData] = None
+        self.prediction_is_in_sample = True
         self.train_data: Optional[InputData] = None
         self.test_data: Optional[InputData] = None
 
@@ -196,7 +197,7 @@ class Fedot:
     def predict(self,
                 features: FeaturesType,
                 save_predictions: bool = False,
-                in_sample: bool = False,
+                in_sample: bool = True,
                 validation_blocks: Optional[int] = None) -> np.ndarray:
         """Predicts new target using already fitted model.
 
@@ -220,12 +221,12 @@ class Fedot:
             raise ValueError(NOT_FITTED_ERR_MSG)
 
         self.test_data = self.data_processor.define_data(target=self.target, features=features, is_predict=True)
-
+        self.prediction_is_in_sample = in_sample
         validation_blocks = validation_blocks or self.params.api_params.get('validation_blocks')
 
         self.prediction = self.data_processor.define_predictions(current_pipeline=self.current_pipeline,
                                                                  test_data=self.test_data,
-                                                                 in_sample=in_sample,
+                                                                 in_sample=self.prediction_is_in_sample,
                                                                  validation_blocks=validation_blocks)
 
         if save_predictions:
@@ -293,6 +294,7 @@ class Fedot:
                                                          is_predict=True)
         predict = out_of_sample_ts_forecast(self.current_pipeline, self.test_data, horizon)
         self.prediction = convert_forecast_to_output(self.test_data, predict)
+        self.prediction_is_in_sample = False
         if save_predictions:
             self.save_predict(self.prediction)
         return self.prediction.predict
@@ -324,7 +326,7 @@ class Fedot:
                          objectives_names=metric_names,
                          show=True)
 
-    def plot_prediction(self, in_sample: bool = False, target: Optional[Any] = None):
+    def plot_prediction(self, in_sample: Optional[bool] = None, target: Optional[Any] = None):
         """Plots the prediction obtained from graph
 
         Args:
@@ -335,6 +337,7 @@ class Fedot:
         """
         if self.prediction is not None:
             if self.params.api_params['task'].task_type == TaskTypesEnum.ts_forecasting:
+                in_sample = in_sample or self.prediction_is_in_sample
                 plot_forecast(self.test_data, self.prediction, in_sample, target)
             elif self.params.api_params['task'].task_type == TaskTypesEnum.regression:
                 plot_biplot(self.prediction)
@@ -351,7 +354,7 @@ class Fedot:
     def get_metrics(self,
                     target: Union[np.ndarray, pd.Series] = None,
                     metric_names: Union[str, List[str]] = None,
-                    in_sample: bool = False,
+                    in_sample: Optional[bool] = None,
                     validation_blocks: Optional[int] = None) -> dict:
         """Gets quality metrics for the fitted graph
 
@@ -394,7 +397,9 @@ class Fedot:
                 if metric_name == "roc_auc":  # for roc-auc we need probabilities
                     prediction.predict = self.predict_proba(self.test_data)
                 else:
-                    prediction.predict = self.predict(self.test_data, in_sample=in_sample,
+                    if in_sample is not None:
+                        self.prediction_is_in_sample = in_sample
+                    prediction.predict = self.predict(self.test_data, in_sample=self.prediction_is_in_sample,
                                                       validation_blocks=validation_blocks)
                 real = deepcopy(self.test_data)
 

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -196,7 +196,9 @@ class Fedot:
     def predict(self,
                 features: FeaturesType,
                 save_predictions: bool = False) -> np.ndarray:
-        """Predicts new target using already fitted model
+        """Predicts new target using already fitted model.
+
+        For time-series performs in-sample forecast if length of idx of InputData is bigger than forecast length.
 
         Args:
             features: the array with features of test data
@@ -309,15 +311,18 @@ class Fedot:
                          objectives_names=metric_names,
                          show=True)
 
-    def plot_prediction(self, target: Optional[Any] = None):
+    def plot_prediction(self, in_sample: bool = False, target: Optional[Any] = None):
         """Plots the prediction obtained from graph
 
         Args:
+            in_sample: if current prediction is in_sample (for time-series forecasting).
+            Plots predictions as future values
             target: user-specified name of target variable for :obj:`MultiModalData`
+
         """
         if self.prediction is not None:
             if self.params.api_params['task'].task_type == TaskTypesEnum.ts_forecasting:
-                plot_forecast(self.test_data, self.prediction, target)
+                plot_forecast(self.test_data, self.prediction, in_sample, target)
             elif self.params.api_params['task'].task_type == TaskTypesEnum.regression:
                 plot_biplot(self.prediction)
             elif self.params.api_params['task'].task_type == TaskTypesEnum.classification:

--- a/fedot/core/data/data_split.py
+++ b/fedot/core/data/data_split.py
@@ -60,12 +60,22 @@ def _split_multi_time_series(data: InputData, task, *args, **kwargs):
     input_target = data.target
     forecast_length = task.task_params.forecast_length
 
-    # Source time series divide into two parts
-    x_train = input_features[:-forecast_length]
-    x_test = input_features[:-forecast_length]
+    if kwargs.get('validation_blocks') is not None:
+        # It is required to split data for in-sample forecasting
+        forecast_length = forecast_length * kwargs.get('validation_blocks')
+        x_train = input_features[:-forecast_length]
+        x_test = input_features
 
-    y_train = input_target[:-forecast_length]
-    y_test = input_target[-forecast_length:, :1]
+        y_train = input_target[:-forecast_length]
+        y_test = input_target[-forecast_length:, 0]
+
+    else:
+        # Source time series divide into two parts
+        x_train = input_features[:-forecast_length]
+        x_test = input_features[:-forecast_length]
+
+        y_train = input_target[:-forecast_length]
+        y_test = input_target[-forecast_length:, 0]
 
     idx_train = data.idx[:-forecast_length]
     idx_test = data.idx[-forecast_length:]

--- a/fedot/core/data/supplementary_data.py
+++ b/fedot/core/data/supplementary_data.py
@@ -10,7 +10,7 @@ from fedot.core.repository.tasks import TaskTypesEnum
 @dataclass
 class SupplementaryData:
     """
-    A class that stores variables for for internal purposes in core during fit
+    A class that stores variables for internal purposes in core during fit
     and predict. For instance, to manage dataflow properties.
     """
     # Is it data in the main branch

--- a/fedot/core/data/visualisation.py
+++ b/fedot/core/data/visualisation.py
@@ -17,7 +17,8 @@ def plot_forecast(data: [InputData, MultiModalData], prediction: OutputData, in_
     Args:
         data: the InputData or MultiModalData with actual time series as features
         prediction: the OutputData with predictions
-        in_sample: if obtained prediction was in sample. Plots predictions as future values.
+        in_sample: if obtained prediction was in sample.
+        If ``False`` plots predictions as future values for test data features.
         target: user-specified name of target variable for MultiModalData
     """
     if isinstance(data, MultiModalData):

--- a/fedot/core/data/visualisation.py
+++ b/fedot/core/data/visualisation.py
@@ -38,7 +38,7 @@ def plot_forecast(data: [InputData, MultiModalData], prediction: OutputData, in_
     elif target_time_series is not None:
         actual_time_series = np.concatenate([actual_time_series, target_time_series], axis=0)
 
-    padding = min(len(actual_time_series), 72)
+    padding = min(pred_start, 72)
 
     first_idx = pred_start - padding
 

--- a/fedot/core/data/visualisation.py
+++ b/fedot/core/data/visualisation.py
@@ -19,20 +19,17 @@ def plot_forecast(data: [InputData, MultiModalData], prediction: OutputData, tar
         if not target:
             raise AttributeError("Can't visualize. Target of MultiModalData not set.")
         data = data.extract_data_source(target)
-    actual_time_series = np.concatenate([data.features, data.target], axis=0)
     target = data.target
     predict = prediction.predict
-    if len(actual_time_series) < 72:
-        padding = len(actual_time_series)
-    else:
-        padding = 72
-
+    actual_time_series = data.features
+    pred_start = len(actual_time_series)
     if target is not None:
+        actual_time_series = np.concatenate([actual_time_series, target], axis=0)
         pred_start = len(actual_time_series) - len(predict)
-        first_idx = pred_start - padding
-    else:
-        pred_start = len(actual_time_series)
-        first_idx = pred_start - padding
+
+    padding = min(len(actual_time_series), 72)
+
+    first_idx = pred_start - padding
 
     plt.plot(np.arange(pred_start, pred_start + len(predict)),
              predict, label='Predicted', c='blue')

--- a/fedot/core/data/visualisation.py
+++ b/fedot/core/data/visualisation.py
@@ -1,3 +1,5 @@
+from typing import Optional, Any
+
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -6,14 +8,17 @@ from fedot.core.data.data import InputData, OutputData
 from fedot.core.data.multi_modal import MultiModalData
 
 
-def plot_forecast(data: [InputData, MultiModalData], prediction: OutputData, target: None):
+def plot_forecast(data: [InputData, MultiModalData], prediction: OutputData, in_sample: bool = False,
+                  target: Optional[Any] = None):
     """
     Function for drawing plot with time series forecast. If data.target is None function plot prediction
     as future values. If not - we use last data features as validation.
 
-    :param data: the InputData or MultiModalData with actual time series as features
-    :param prediction: the OutputData with predictions
-    :param target: user-specified name of target variable for MultiModalData
+    Args:
+        data: the InputData or MultiModalData with actual time series as features
+        prediction: the OutputData with predictions
+        in_sample: if obtained prediction was in sample. Plots predictions as future values.
+        target: user-specified name of target variable for MultiModalData
     """
     if isinstance(data, MultiModalData):
         if not target:
@@ -23,9 +28,10 @@ def plot_forecast(data: [InputData, MultiModalData], prediction: OutputData, tar
     predict = prediction.predict
     actual_time_series = data.features
     pred_start = len(actual_time_series)
-    if target is not None:
-        actual_time_series = np.concatenate([actual_time_series, target], axis=0)
+    if in_sample:
         pred_start = len(actual_time_series) - len(predict)
+    elif target is not None:
+        actual_time_series = np.concatenate([actual_time_series, target], axis=0)
 
     padding = min(len(actual_time_series), 72)
 

--- a/fedot/core/data/visualisation.py
+++ b/fedot/core/data/visualisation.py
@@ -30,13 +30,13 @@ def plot_forecast(data: [InputData, MultiModalData], prediction: OutputData, in_
         actual_time_series = data.features[:, 0]
     else:
         actual_time_series = data.features
-    target = data.target
+    target_time_series = data.target
     predict = prediction.predict
     pred_start = len(actual_time_series)
     if in_sample:
         pred_start = len(actual_time_series) - len(predict)
-    elif target is not None:
-        actual_time_series = np.concatenate([actual_time_series, target], axis=0)
+    elif target_time_series is not None:
+        actual_time_series = np.concatenate([actual_time_series, target_time_series], axis=0)
 
     padding = min(len(actual_time_series), 72)
 

--- a/fedot/core/data/visualisation.py
+++ b/fedot/core/data/visualisation.py
@@ -6,6 +6,7 @@ import numpy as np
 from fedot.core.composer.metrics import ROCAUC
 from fedot.core.data.data import InputData, OutputData
 from fedot.core.data.multi_modal import MultiModalData
+from fedot.core.repository.dataset_types import DataTypesEnum
 
 
 def plot_forecast(data: [InputData, MultiModalData], prediction: OutputData, in_sample: bool = False,
@@ -25,9 +26,12 @@ def plot_forecast(data: [InputData, MultiModalData], prediction: OutputData, in_
         if not target:
             raise AttributeError("Can't visualize. Target of MultiModalData not set.")
         data = data.extract_data_source(target)
+    if data.data_type == DataTypesEnum.multi_ts:
+        actual_time_series = data.features[:, 0]
+    else:
+        actual_time_series = data.features
     target = data.target
     predict = prediction.predict
-    actual_time_series = data.features
     pred_start = len(actual_time_series)
     if in_sample:
         pred_start = len(actual_time_series) - len(predict)

--- a/fedot/core/pipelines/ts_wrappers.py
+++ b/fedot/core/pipelines/ts_wrappers.py
@@ -313,13 +313,17 @@ def convert_forecast_to_output(pre_history_data: Union[InputData, MultiModalData
     Args:
         pre_history_data: data which was used for prediction
         forecast: array with predicted values
-        idx: array with idx values. If None sets next idx after `pre_history_data` with length of forecast.
+        idx: array with idx values. If None sets next idx after `pre_history_data` with length of forecast for InputData
+        and idx from 0 to forecast length for MultimodalData.
     """
     features = pre_history_data.features if isinstance(pre_history_data, InputData) else None
     if forecast.ndim > 1:
         forecast = np.squeeze(forecast)
     if idx is None:
-        idx = pre_history_data.idx
+        if features is not None:
+            idx = np.arange(len(features), len(features) + len(forecast))
+        else:
+            idx = np.arange(len(forecast))
     prediction = OutputData(idx=idx,
                             features=features,
                             predict=forecast,

--- a/fedot/core/pipelines/ts_wrappers.py
+++ b/fedot/core/pipelines/ts_wrappers.py
@@ -319,9 +319,7 @@ def convert_forecast_to_output(pre_history_data: Union[InputData, MultiModalData
     if forecast.ndim > 1:
         forecast = np.squeeze(forecast)
     if idx is None:
-        start_idx = pre_history_data.idx[-1] + 1
-        end_idx = start_idx + len(forecast)
-        idx = np.arange(start_idx, end_idx)
+        idx = pre_history_data.idx
     prediction = OutputData(idx=idx,
                             features=features,
                             predict=forecast,

--- a/fedot/core/validation/split.py
+++ b/fedot/core/validation/split.py
@@ -7,6 +7,7 @@ from sklearn.model_selection._split import _BaseKFold
 from fedot.core.data.data import InputData
 from fedot.core.data.data_split import train_test_data_setup
 from fedot.core.log import LoggerAdapter, default_log
+from fedot.core.repository.dataset_types import DataTypesEnum
 
 
 class OneFoldInputDataSplit:
@@ -157,5 +158,9 @@ def _ts_data_by_index(train_ids, test_ids, data):
     """ Allow to get time series data by indexes of elements """
     features = data.features[train_ids]
     target = data.target[test_ids]
+
+    # Use only the first time-series as target for multi_ts
+    if data.data_type == DataTypesEnum.multi_ts:
+        target = target[:, 0]
 
     return features, target

--- a/test/unit/api/test_main_api.py
+++ b/test/unit/api/test_main_api.py
@@ -172,7 +172,7 @@ def test_api_forecast_numpy_input_with_static_model_correct(task_type: str = 'ts
     model.fit(features=train_data.features,
               target=train_data.target,
               predefined_model=pipeline)
-    ts_forecast = model.predict(features=train_data)
+    ts_forecast = model.predict(features=test_data)
     metric = model.get_metrics(target=test_data.target, metric_names='rmse')
 
     assert len(ts_forecast) == forecast_length

--- a/test/unit/api/test_main_api.py
+++ b/test/unit/api/test_main_api.py
@@ -145,7 +145,7 @@ def test_api_predict_correct(task_type, predefined_model, metric_name):
     assert is_predict_ignores_target(model.predict, train_data, 'features')
 
 
-def test_api_simple_forecast_correct(task_type: str = 'ts_forecasting'):
+def test_api_simple_ts_predict_correct(task_type: str = 'ts_forecasting'):
     # The forecast length must be equal to 5
     forecast_length = 5
     train_data, test_data, _ = get_dataset(task_type)
@@ -154,13 +154,13 @@ def test_api_simple_forecast_correct(task_type: str = 'ts_forecasting'):
 
     model.fit(features=train_data)
     ts_forecast = model.predict(features=test_data)
-    metric = model.get_metrics(target=test_data.target, metric_names='rmse')
+    _ = model.get_metrics(target=test_data.target, metric_names='rmse')
 
     assert len(ts_forecast) == forecast_length
 
 
 @pytest.mark.parametrize('validation_blocks', [None, 2, 3])
-def test_api_in_sample_forecast_correct(validation_blocks, task_type: str = 'ts_forecasting'):
+def test_api_in_sample_ts_forecast_correct(validation_blocks, task_type: str = 'ts_forecasting'):
     # The forecast length must be equal to 5
     forecast_length = 5
     train_data, test_data, _ = get_dataset(task_type, validation_blocks=validation_blocks)
@@ -170,7 +170,7 @@ def test_api_in_sample_forecast_correct(validation_blocks, task_type: str = 'ts_
 
     model.fit(features=train_data)
     ts_forecast = model.predict(features=test_data, in_sample=True)
-    metric = model.get_metrics(target=test_data.target, metric_names='rmse', in_sample=True)
+    _ = model.get_metrics(target=test_data.target, metric_names='rmse', in_sample=True)
 
     assert len(ts_forecast) == forecast_length * validation_blocks if validation_blocks else forecast_length
 

--- a/test/unit/api/test_main_api.py
+++ b/test/unit/api/test_main_api.py
@@ -10,6 +10,7 @@ from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelEncoder
 
 from cases.metocean_forecasting_problem import prepare_input_data
+from examples.simple.time_series_forecasting.ts_pipelines import ts_complex_ridge_smoothing_pipeline
 from fedot.api.api_utils.api_composer import _divide_parameters
 from fedot.api.api_utils.api_data import ApiDataProcessor
 from fedot.api.main import Fedot
@@ -168,10 +169,11 @@ def test_api_simple_ts_predict_correct(task_type: str = 'ts_forecasting'):
     forecast_length = 5
     train_data, test_data, _ = get_dataset(task_type, validation_blocks=1)
     model = Fedot(problem='ts_forecasting', **default_params,
-                  task_params=TsForecastingParams(forecast_length=forecast_length))
+                  task_params=TsForecastingParams(forecast_length=forecast_length),
+                  validation_blocks=1)
 
-    model.fit(features=train_data)
-    ts_forecast = model.predict(features=test_data, in_sample=False)
+    model.fit(features=train_data, predefined_model='auto')
+    ts_forecast = model.predict(features=test_data)
     _ = model.get_metrics(target=test_data.target, metric_names='rmse')
 
     assert len(ts_forecast) == forecast_length
@@ -186,7 +188,7 @@ def test_api_in_sample_ts_predict_correct(validation_blocks, task_type: str = 't
                   task_params=TsForecastingParams(forecast_length=forecast_length),
                   validation_blocks=validation_blocks)
 
-    model.fit(features=train_data)
+    model.fit(features=train_data, predefined_model='auto')
     ts_forecast = model.predict(features=test_data, validation_blocks=validation_blocks)
     _ = model.get_metrics(target=test_data.target, metric_names='rmse', validation_blocks=validation_blocks)
 
@@ -203,7 +205,7 @@ def test_api_in_sample_multi_ts_predict_correct(validation_blocks, task_type: st
                   available_operations=['lagged', 'smoothing', 'diff_filter', 'gaussian_filter',
                                         'ridge', 'lasso', 'linear', 'cut'])
 
-    model.fit(features=train_data)
+    model.fit(features=train_data, predefined_model=ts_complex_ridge_smoothing_pipeline())
     ts_forecast = model.predict(features=test_data, validation_blocks=validation_blocks)
     _ = model.get_metrics(target=test_data.target, metric_names='rmse', validation_blocks=validation_blocks)
 

--- a/test/unit/api/test_main_api.py
+++ b/test/unit/api/test_main_api.py
@@ -145,17 +145,32 @@ def test_api_predict_correct(task_type, predefined_model, metric_name):
     assert is_predict_ignores_target(model.predict, train_data, 'features')
 
 
-@pytest.mark.parametrize('validation_blocks', [None, 2, 3])
-def test_api_forecast_correct(validation_blocks, task_type: str = 'ts_forecasting'):
+def test_api_simple_forecast_correct(task_type: str = 'ts_forecasting'):
     # The forecast length must be equal to 5
     forecast_length = 5
-    train_data, test_data, _ = get_dataset(task_type, validation_blocks=validation_blocks)
+    train_data, test_data, _ = get_dataset(task_type)
     model = Fedot(problem='ts_forecasting', **default_params,
                   task_params=TsForecastingParams(forecast_length=forecast_length))
 
     model.fit(features=train_data)
     ts_forecast = model.predict(features=test_data)
     metric = model.get_metrics(target=test_data.target, metric_names='rmse')
+
+    assert len(ts_forecast) == forecast_length
+
+
+@pytest.mark.parametrize('validation_blocks', [None, 2, 3])
+def test_api_in_sample_forecast_correct(validation_blocks, task_type: str = 'ts_forecasting'):
+    # The forecast length must be equal to 5
+    forecast_length = 5
+    train_data, test_data, _ = get_dataset(task_type, validation_blocks=validation_blocks)
+    model = Fedot(problem='ts_forecasting', **default_params,
+                  task_params=TsForecastingParams(forecast_length=forecast_length),
+                  validation_blocks=validation_blocks)
+
+    model.fit(features=train_data)
+    ts_forecast = model.predict(features=test_data, in_sample=True)
+    metric = model.get_metrics(target=test_data.target, metric_names='rmse', in_sample=True)
 
     assert len(ts_forecast) == forecast_length * validation_blocks if validation_blocks else forecast_length
 

--- a/test/unit/tasks/test_forecasting.py
+++ b/test/unit/tasks/test_forecasting.py
@@ -1,6 +1,7 @@
 import os
 from copy import deepcopy
 from random import seed
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -33,7 +34,7 @@ def _max_rmse_threshold_by_std(values, is_strict=True):
     return np.std(values) * tolerance_coeff
 
 
-def get_ts_data(n_steps=80, forecast_length=5):
+def get_ts_data(n_steps: int = 80, forecast_length: int = 5, validation_blocks: Optional[int] = None):
     """ Prepare data from csv file with time series and take needed number of
     elements
 
@@ -53,7 +54,7 @@ def get_ts_data(n_steps=80, forecast_length=5):
                      target=time_series,
                      task=task,
                      data_type=DataTypesEnum.ts)
-    return train_test_data_setup(data)
+    return train_test_data_setup(data, validation_blocks=validation_blocks)
 
 
 def get_ts_data_with_dt_idx(n_steps=80, forecast_length=5):

--- a/test/unit/tasks/test_forecasting.py
+++ b/test/unit/tasks/test_forecasting.py
@@ -40,6 +40,7 @@ def get_ts_data(n_steps: int = 80, forecast_length: int = 5, validation_blocks: 
 
     :param n_steps: number of elements in time series to take
     :param forecast_length: the length of forecast
+    :param validation_blocks: number of validation blocks
     """
     project_root_path = str(fedot_project_root())
     file_path = os.path.join(project_root_path, 'test/data/simple_time_series.csv')

--- a/test/unit/tasks/test_multi_ts_forecast.py
+++ b/test/unit/tasks/test_multi_ts_forecast.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 import numpy as np
 
@@ -10,7 +11,7 @@ from fedot.core.repository.tasks import Task, TaskTypesEnum, TsForecastingParams
 from fedot.core.utils import fedot_project_root
 
 
-def get_multi_ts_data():
+def get_multi_ts_data(validation_blocks: Optional[int] = None):
     task = Task(TaskTypesEnum.ts_forecasting,
                 TsForecastingParams(forecast_length=5))
     project_root_path = str(fedot_project_root())
@@ -18,7 +19,7 @@ def get_multi_ts_data():
     data = InputData.from_csv_multi_time_series(
         file_path=file_path,
         task=task)
-    train_data, test_data = train_test_data_setup(data)
+    train_data, test_data = train_test_data_setup(data, validation_blocks=validation_blocks)
     return train_data, test_data
 
 
@@ -51,7 +52,7 @@ def get_linear_pipeline():
     return pipeline
 
 
-def test_multi_ts_forecasting():
+def test_multi_ts_predict():
     train_data, test_data = get_multi_ts_data()
     pipeline = get_linear_pipeline()
     pipeline.fit(train_data)

--- a/test/unit/tasks/test_multi_ts_forecast.py
+++ b/test/unit/tasks/test_multi_ts_forecast.py
@@ -11,9 +11,9 @@ from fedot.core.repository.tasks import Task, TaskTypesEnum, TsForecastingParams
 from fedot.core.utils import fedot_project_root
 
 
-def get_multi_ts_data(validation_blocks: Optional[int] = None):
+def get_multi_ts_data(forecast_length: int = 5, validation_blocks: Optional[int] = None):
     task = Task(TaskTypesEnum.ts_forecasting,
-                TsForecastingParams(forecast_length=5))
+                TsForecastingParams(forecast_length=forecast_length))
     project_root_path = str(fedot_project_root())
     file_path = os.path.join(project_root_path, 'test/data/synthetic_multi_ts.csv')
     data = InputData.from_csv_multi_time_series(


### PR DESCRIPTION
FEDOT API predict now can be in-sample. 

Output of  ``.predict(test_data)`` is a forecast with depth ``forecasting_length*validation_blocks``  using ``test_data.features[-forecasting_length*validation_blocks:]``.

Output of  ``.forecast(test_data)`` is a forecast with depth ``forecasting_length``, using ``test_data.features`` as pre_history. 

To get in-sample predict with n steps:
- use ``train_test_data_setup(train_input, validation_blocks=n)``
- ``model = Fedot(..., validation_blocks=n, ...)``
-  ``model.predict(test_data)``
- ``model.get_metrics()``
- ``model.plot_prediction()``

![image](https://user-images.githubusercontent.com/43475193/199499002-fe46fab6-ee64-48ca-a9a3-8a9a39ce7243.png)

To get out-of-sample forecast with n steps:
- use ``train_test_data_setup(train_input)``
-  ``model.forecast(test_data, horison=forecast_length * n)``
- ``model.plot_prediction()``

Green line after vertical line is ``test_data.target``

![image](https://user-images.githubusercontent.com/43475193/199499782-df2428b3-dec9-4ea2-9fe3-e651b0a1714e.png)
