### PR TITLE
Fix getting suitable operations for multi ts 

### DIFF
--- a/cases/multi_ts_level_forecasting.py
+++ b/cases/multi_ts_level_forecasting.py
@@ -67,9 +67,7 @@ def run_multi_ts_forecast(forecast_length, is_multi_ts):
                   max_arity=4,
                   cv_folds=None,
                   validation_blocks=None,
-                  initial_assumption=init_pipeline,
-                  available_operations=['lagged', 'smoothing', 'diff_filter', 'gaussian_filter',
-                                        'ridge', 'lasso', 'linear', 'cut']
+                  initial_assumption=init_pipeline
                   )
     # fit model
     pipeline = model.fit(train_data)

--- a/examples/simple/interpretable/api_explain.py
+++ b/examples/simple/interpretable/api_explain.py
@@ -31,4 +31,4 @@ def run_api_explain_example(visualization=False, timeout=None):
 
 
 if __name__ == '__main__':
-    run_api_explain_example(visualization=True)
+    run_api_explain_example(visualization=True, timeout=5)

--- a/examples/simple/time_series_forecasting/api_forecasting.py
+++ b/examples/simple/time_series_forecasting/api_forecasting.py
@@ -36,7 +36,7 @@ def run_ts_forecasting_example(dataset='australia', horizon: int = 30, validatio
                             target=time_series,
                             task=task,
                             data_type=DataTypesEnum.ts)
-    train_data, test_data = train_test_data_setup(train_input, validation_blocks=validation_blocks)
+    train_data, test_data = train_test_data_setup(train_input)
 
     # init model for the time series forecasting
     model = Fedot(problem='ts_forecasting',
@@ -50,8 +50,7 @@ def run_ts_forecasting_example(dataset='australia', horizon: int = 30, validatio
 
     # use model to obtain forecast
     forecast = model.predict(test_data)
-    target = np.ravel(test_data.target)
-    print(model.get_metrics(metric_names=['rmse', 'mae', 'mape'], target=target))
+    print(model.get_metrics(metric_names=['rmse', 'mae', 'mape'], target=test_data.target))
 
     # plot forecasting result
     if visualization:

--- a/fedot/api/api_utils/assumptions/assumptions_builder.py
+++ b/fedot/api/api_utils/assumptions/assumptions_builder.py
@@ -64,7 +64,7 @@ class UniModalAssumptionsBuilder(AssumptionsBuilder):
 
     def from_operations(self, available_operations: Optional[List[str]] = None):
         if available_operations:
-            operations_for_task_and_data = self.repo.suitable_operation(self.data.task.task_type)
+            operations_for_task_and_data = self.repo.suitable_operation(self.data.task.task_type, self.data_type)
             operations_to_choose_from = set(operations_for_task_and_data).intersection(available_operations)
             _check_operations_to_choose_from(self.data, self.data_type, operations_to_choose_from)
             if operations_to_choose_from:

--- a/fedot/api/api_utils/assumptions/assumptions_builder.py
+++ b/fedot/api/api_utils/assumptions/assumptions_builder.py
@@ -8,7 +8,6 @@ from fedot.core.data.data import InputData
 from fedot.core.data.multi_modal import MultiModalData
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.operation_types_repository import OperationTypesRepository
-from fedot.core.repository.tasks import TaskTypesEnum
 from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.pipelines.pipeline_builder import PipelineBuilder, Node
 

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -166,6 +166,7 @@ class Fedot:
         self.data_processor.accept_and_apply_recommendations(self.train_data, recommendations)
         self.params.accept_and_apply_recommendations(self.train_data, recommendations)
         self._init_remote_if_necessary()
+        self.params.update_available_operations_by_preset(self.train_data)
         self.params.api_params['train_data'] = self.train_data
 
         if predefined_model is not None:

--- a/fedot/core/optimisers/populational_optimizer.py
+++ b/fedot/core/optimisers/populational_optimizer.py
@@ -57,8 +57,8 @@ class PopulationalOptimizer(GraphOptimizer):
                 lambda: self.timer.is_time_limit_reached(self.current_generation_num),
                 'Optimisation stopped: Time limit is reached'
             ).add_condition(
-                lambda: requirements.num_of_generations is not None and
-                        self.current_generation_num >= requirements.num_of_generations + 1,
+                lambda: self.requirements.num_of_generations is not None and
+                        self.current_generation_num >= self.requirements.num_of_generations + 1,
                 'Optimisation stopped: Max number of generations reached'
             ).add_condition(
                 lambda: self.generations.stagnation_iter_count >= max_stagnation_length,

--- a/fedot/core/repository/data/model_repository.json
+++ b/fedot/core/repository/data/model_repository.json
@@ -78,7 +78,7 @@
       ],
       "description": "Implementations of the regression models from scikit-learn framework",
       "forbidden_node_types": "[]",
-      "input_type": "[DataTypesEnum.table]",
+      "input_type": "[DataTypesEnum.table, DataTypesEnum.multi_ts]",
       "output_type": "[DataTypesEnum.table]",
       "strategies": [
         "fedot.core.operations.evaluation.regression",
@@ -93,7 +93,7 @@
     },
     "ts_model": {
       "description": "Implementations of the time series models",
-      "input_type": "[DataTypesEnum.ts, DataTypesEnum.multi_ts]",
+      "input_type": "[DataTypesEnum.ts]",
       "output_type": "[DataTypesEnum.table]",
       "strategies": [
         "fedot.core.operations.evaluation.time_series",

--- a/fedot/core/repository/operation_types_repository.py
+++ b/fedot/core/repository/operation_types_repository.py
@@ -300,7 +300,7 @@ class OperationTypesRepository:
                 operations_info.append(o)
 
         if data_type:
-            # ignore text and image data types: no operations defines these `input_types`
+            # ignore text and image data types: there are no operations with these `input_type`
             ignore_data_type = data_type in [DataTypesEnum.text, DataTypesEnum.image]
             if data_type == DataTypesEnum.ts:
                 valid_data_types = [DataTypesEnum.ts, DataTypesEnum.table]
@@ -399,12 +399,13 @@ def atomized_model_meta_tags():
     return ['random'], ['any'], ['atomized']
 
 
-def get_operations_for_task(task: Optional[Task], mode='all', tags=None, forbidden_tags=None,
-                            preset: str = None):
+def get_operations_for_task(task: Optional[Task], data_type: Optional[DataTypesEnum] = None, mode='all', tags=None,
+                            forbidden_tags=None, preset: str = None):
     """Function returns aliases of operations.
 
     Args:
         task: task to solve
+        data_type: type of input data
         mode: mode to return operations
 
             .. details:: the possible parameters of ``mode``:
@@ -429,7 +430,7 @@ def get_operations_for_task(task: Optional[Task], mode='all', tags=None, forbidd
     task_type = task.task_type if task else None
     if mode in AVAILABLE_REPO_NAMES:
         repo = OperationTypesRepository(mode)
-        model_types = repo.suitable_operation(task_type, tags=tags, forbidden_tags=forbidden_tags,
+        model_types = repo.suitable_operation(task_type, data_type=data_type, tags=tags, forbidden_tags=forbidden_tags,
                                               preset=preset)
         return model_types
     else:


### PR DESCRIPTION
Previously data_type was not used while getting suitable operations during model composition. That was causing problems described [here](https://github.com/aimclub/FEDOT/issues/974)
Changes:
- available_operations are defined during fit strage to take ```input_data.data_type``` into account
- new method ```ApiParams.update_available_operations_by_preset``` were created
- filterring operations by data_type in ```OperationTypesRepository.suitable_operations``` was fixed to not filter out to many operations