### PR TITLE
Search near init params and some mini fixes

### DIFF
--- a/cases/river_levels_prediction/river_level_case_manual.py
+++ b/cases/river_levels_prediction/river_level_case_manual.py
@@ -73,8 +73,6 @@ def run_river_experiment(file_path, pipeline, iterations=20, tuner=None,
 
             # Predict
             predicted_values_tuned = tuned_pipeline.predict(predict_input)
-
-            tuned_pipeline.print_structure()
             preds_tuned = predicted_values_tuned.predict
 
             mse_value = mean_squared_error(y_data_test, preds_tuned,
@@ -98,5 +96,5 @@ if __name__ == '__main__':
     # Available tuners for application: PipelineTuner, NodesTuner
     run_river_experiment(file_path='../data/river_levels/station_levels.csv',
                          pipeline=init_pipeline,
-                         iterations=3,
+                         iterations=20,
                          tuner=PipelineTuner)

--- a/cases/river_levels_prediction/river_level_case_manual.py
+++ b/cases/river_levels_prediction/river_level_case_manual.py
@@ -73,6 +73,8 @@ def run_river_experiment(file_path, pipeline, iterations=20, tuner=None,
 
             # Predict
             predicted_values_tuned = tuned_pipeline.predict(predict_input)
+
+            tuned_pipeline.print_structure()
             preds_tuned = predicted_values_tuned.predict
 
             mse_value = mean_squared_error(y_data_test, preds_tuned,
@@ -96,5 +98,5 @@ if __name__ == '__main__':
     # Available tuners for application: PipelineTuner, NodesTuner
     run_river_experiment(file_path='../data/river_levels/station_levels.csv',
                          pipeline=init_pipeline,
-                         iterations=20,
+                         iterations=3,
                          tuner=PipelineTuner)

--- a/examples/simple/pipeline_tune.py
+++ b/examples/simple/pipeline_tune.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import numpy as np
 from sklearn.metrics import roc_auc_score as roc_auc
 
@@ -34,16 +36,17 @@ def pipeline_tuning(pipeline: Pipeline, train_data: InputData,
     :return several_iter_scores_test: list with metrics
     """
     several_iter_scores_test = []
+    tuner = TunerBuilder(train_data.task) \
+        .with_tuner(PipelineTuner) \
+        .with_metric(ClassificationMetricsEnum.ROCAUC) \
+        .with_iterations(tuner_iter_num) \
+        .build(train_data)
     for iteration in range(local_iter):
         print(f'current local iteration {iteration}')
 
         # Pipeline tuning
-        tuner = TunerBuilder(train_data.task)\
-            .with_tuner(PipelineTuner)\
-            .with_metric(ClassificationMetricsEnum.ROCAUC)\
-            .with_iterations(tuner_iter_num) \
-            .build(train_data)
-        tuned_pipeline = tuner.tune(pipeline)
+        pipeline_copy = deepcopy(pipeline)
+        tuned_pipeline = tuner.tune(pipeline_copy)
 
         # After tuning prediction
         tuned_pipeline.fit(train_data)

--- a/examples/simple/pipeline_tune.py
+++ b/examples/simple/pipeline_tune.py
@@ -45,8 +45,7 @@ def pipeline_tuning(pipeline: Pipeline, train_data: InputData,
         print(f'current local iteration {iteration}')
 
         # Pipeline tuning
-        pipeline_copy = deepcopy(pipeline)
-        tuned_pipeline = tuner.tune(pipeline_copy)
+        tuned_pipeline = tuner.tune(pipeline)
 
         # After tuning prediction
         tuned_pipeline.fit(train_data)
@@ -57,8 +56,8 @@ def pipeline_tuning(pipeline: Pipeline, train_data: InputData,
                                   y_score=after_tuning_predicted.predict)
         several_iter_scores_test.append(aft_tun_roc_auc)
 
-    mean_metric = float(np.mean(several_iter_scores_test))
-    return mean_metric, several_iter_scores_test
+    max_metric = float(np.max(several_iter_scores_test))
+    return max_metric, several_iter_scores_test
 
 
 if __name__ == '__main__':
@@ -81,6 +80,6 @@ if __name__ == '__main__':
                                                                    local_iter=local_iter)
 
     print(f'Several test scores {several_iter_scores_test}')
-    print(f'Mean test score over {local_iter} iterations: {after_tune_roc_auc}')
-    print(round(bfr_tun_roc_auc, 3))
-    print(round(after_tune_roc_auc, 3))
+    print(f'Maximal test score over {local_iter} iterations: {after_tune_roc_auc}')
+    print(f'ROC-AUC before tuning {round(bfr_tun_roc_auc, 3)}')
+    print(f'ROC-AUC after tuning {round(after_tune_roc_auc, 3)}')

--- a/fedot/api/api_utils/api_composer.py
+++ b/fedot/api/api_utils/api_composer.py
@@ -316,7 +316,7 @@ class ApiComposer:
                 self.log.message('Hyperparameters tuning finished')
         else:
             self.log.message(f'Time for pipeline composing was {str(self.timer.composing_spend_time)}.\n'
-                             f'The remaining {max(0, timeout_for_tuning)} seconds are not enough '
+                             f'The remaining {max(0, round(timeout_for_tuning, 1))} seconds are not enough '
                              f'to tune the hyperparameters.')
             self.log.message('Composed pipeline returned without tuning.')
             tuned_pipeline = pipeline_gp_composed

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -188,7 +188,7 @@ class Fedot:
         self.current_pipeline.preprocessor = merge_preprocessors(self.data_processor.preprocessor,
                                                                  self.current_pipeline.preprocessor)
 
-        self.params.api_params['logger'].message(f'Final pipeline: {str(self.current_pipeline)}')
+        self.params.api_params['logger'].message(f'Final pipeline: {self.current_pipeline.structure}')
 
         return self.current_pipeline
 

--- a/fedot/core/optimisers/objective/data_objective_eval.py
+++ b/fedot/core/optimisers/objective/data_objective_eval.py
@@ -89,6 +89,7 @@ class PipelineObjectiveEvaluate(ObjectiveEvaluate[Pipeline]):
             self._log.debug(f'Pipeline {graph_id} with evaluated metrics: {folds_metrics}')
         else:
             folds_metrics = None
+
         return to_fitness(folds_metrics, self._objective.is_multi_objective)
 
     def prepare_graph(self, graph: Pipeline, train_data: InputData,

--- a/fedot/core/optimisers/populational_optimizer.py
+++ b/fedot/core/optimisers/populational_optimizer.py
@@ -119,8 +119,8 @@ class PopulationalOptimizer(GraphOptimizer):
 
         self.log.info(f'Generation num: {self.current_generation_num}')
         self.log.info(f'Best individuals: {str(self.generations)}')
-        if self.generations.stagnation_duration > 0:
-            self.log.info(f'no improvements for {self.generations.stagnation_duration} iterations')
+        if self.generations.stagnation_iter_count > 0:
+            self.log.info(f'no improvements for {self.generations.stagnation_iter_count} iterations')
             self.log.info(f'spent time: {round(self.timer.minutes_from_start, 1)} min')
 
     def _log_to_history(self, population: PopulationT, label: Optional[str] = None,

--- a/fedot/core/optimisers/populational_optimizer.py
+++ b/fedot/core/optimisers/populational_optimizer.py
@@ -119,8 +119,9 @@ class PopulationalOptimizer(GraphOptimizer):
 
         self.log.info(f'Generation num: {self.current_generation_num}')
         self.log.info(f'Best individuals: {str(self.generations)}')
-        self.log.info(f'no improvements for {self.generations.stagnation_iter_count} iterations')
-        self.log.info(f'spent time: {round(self.timer.minutes_from_start, 1)} min')
+        if self.generations.stagnation_duration > 0:
+            self.log.info(f'no improvements for {self.generations.stagnation_duration} iterations')
+            self.log.info(f'spent time: {round(self.timer.minutes_from_start, 1)} min')
 
     def _log_to_history(self, population: PopulationT, label: Optional[str] = None,
                         metadata: Optional[Dict[str, Any]] = None):

--- a/fedot/core/pipelines/node.py
+++ b/fedot/core/pipelines/node.py
@@ -1,9 +1,8 @@
 from dataclasses import dataclass
-from typing import Any, List, Optional, Tuple, Union, Iterable
+from typing import Any, List, Optional, Tuple, Union
 
 import numpy as np
 
-from fedot.core.dag.graph_node import GraphNode
 from fedot.core.dag.linked_graph_node import LinkedGraphNode
 from fedot.core.data.data import InputData, OutputData
 from fedot.core.data.merge.data_merger import DataMerger

--- a/fedot/core/pipelines/pipeline.py
+++ b/fedot/core/pipelines/pipeline.py
@@ -337,14 +337,22 @@ class Pipeline(GraphDelegate, Serializable):
             return None
         return input_data
 
+    @property
+    def structure(self) -> str:
+        """ Structural information about the pipeline
+
+            Returns:
+                string with pipeline structure
+        """
+        return '\n'.join([str(self), *(f'{node.operation.operation_type} - {node.parameters}' for node in self.nodes)])
+
     def print_structure(self):
-        """ Prints structural information about the pipeline
+        """ Prints structure of the pipeline
         """
 
         print(
             'Pipeline structure:',
-            self,
-            *(f'{node.operation.operation_type} - {node.parameters}' for node in self.nodes),
+            self.structure,
             sep='\n'
         )
 

--- a/fedot/core/pipelines/tuning/search_space.py
+++ b/fedot/core/pipelines/tuning/search_space.py
@@ -24,12 +24,12 @@ class SearchSpace:
                 'n_clusters': (hp.uniformint, [2, 7])
             },
             'adareg': {
-                'n_estimators': (hp.choice, [[100]]),
+
                 'learning_rate': (hp.loguniform, [np.log(1e-3), np.log(1)]),
                 'loss': (hp.choice, [["linear", "square", "exponential"]])
             },
             'gbr': {
-                'n_estimators': (hp.choice, [[100]]),
+
                 'loss': (hp.choice, [["ls", "lad", "huber", "quantile"]]),
                 'learning_rate': (hp.loguniform, [np.log(1e-3), np.log(1)]),
                 'max_depth': (hp.uniformint, [1, 11]),
@@ -43,7 +43,6 @@ class SearchSpace:
                 'C': (hp.uniform, [1e-2, 10.0])
             },
             'rf': {
-                'n_estimators': (hp.choice, [[100]]),
                 'criterion': (hp.choice, [["gini", "entropy"]]),
                 'max_features': (hp.uniform, [0.05, 1.0]),
                 'min_samples_split': (hp.uniformint, [2, 10]),
@@ -57,14 +56,14 @@ class SearchSpace:
                 'alpha': (hp.uniform, [0.01, 10.0])
             },
             'rfr': {
-                'n_estimators': (hp.choice, [[100]]),
+
                 'max_features': (hp.uniform, [0.05, 1.0]),
                 'min_samples_split': (hp.uniformint, [2, 21]),
                 'min_samples_leaf': (hp.uniformint, [1, 21]),
                 'bootstrap': (hp.choice, [[True, False]])
             },
             'xgbreg': {
-                'n_estimators': (hp.choice, [[100]]),
+
                 'max_depth': (hp.uniformint, [1, 11]),
                 'learning_rate': (hp.loguniform, [np.log(1e-3), np.log(1)]),
                 'subsample': (hp.uniform, [0.05, 1.0]),
@@ -72,7 +71,7 @@ class SearchSpace:
                 'objective': (hp.choice, [['reg:squarederror']])
             },
             'xgboost': {
-                'n_estimators': (hp.choice, [[100]]),
+
                 'max_depth': (hp.uniformint, [1, 7]),
                 'learning_rate': (hp.loguniform, [np.log(1e-3), np.log(1)]),
                 'subsample': (hp.uniform, [0.05, 0.99]),
@@ -90,7 +89,7 @@ class SearchSpace:
                 'min_samples_leaf': (hp.uniformint, [1, 21])
             },
             'treg': {
-                'n_estimators': (hp.choice, [[100]]),
+
                 'max_features': (hp.uniform, [0.05, 1.0]),
                 'min_samples_split': (hp.uniformint, [2, 21]),
                 'min_samples_leaf': (hp.uniformint, [1, 21]),

--- a/fedot/core/pipelines/tuning/search_space.py
+++ b/fedot/core/pipelines/tuning/search_space.py
@@ -345,11 +345,7 @@ class SearchSpace:
         else:
             params_dict = {}
             for parameter_name in params_list:
-                # Name with operation and parameter
-                op_parameter_name = ''.join((operation_name, ' | ', parameter_name))
-
-                # Name with node id || operation | parameter
-                node_op_parameter_name = ''.join((str(node_id), ' || ', op_parameter_name))
+                node_op_parameter_name = get_node_operation_parameter_label(node_id, operation_name, parameter_name)
 
                 # For operation get range where search can be done
                 space = self.get_operation_parameter_range(operation_name=operation_name,
@@ -359,6 +355,15 @@ class SearchSpace:
                 params_dict.update({node_op_parameter_name: space})
 
         return params_dict
+
+
+def get_node_operation_parameter_label(node_id: int, operation_name: str, parameter_name: str) -> str:
+    # Name with operation and parameter
+    op_parameter_name = ''.join((operation_name, ' | ', parameter_name))
+
+    # Name with node id || operation | parameter
+    node_op_parameter_name = ''.join((str(node_id), ' || ', op_parameter_name))
+    return node_op_parameter_name
 
 
 def convert_params(params):

--- a/fedot/core/pipelines/tuning/tuner_interface.py
+++ b/fedot/core/pipelines/tuning/tuner_interface.py
@@ -68,6 +68,7 @@ class HyperoptTuner(ABC):
         Returns:
           value of loss function
         """
+        pipeline.unfit()
         pipeline_fitness = self.objective_evaluate.evaluate(pipeline)
         metric_value = pipeline_fitness.value
         if not pipeline_fitness.valid:

--- a/fedot/core/pipelines/tuning/tuner_interface.py
+++ b/fedot/core/pipelines/tuning/tuner_interface.py
@@ -88,6 +88,8 @@ class HyperoptTuner(ABC):
         self.init_pipeline = deepcopy(pipeline)
 
         self.init_metric = self.get_metric_value(pipeline=self.init_pipeline)
+        self.log.message(f'Initial pipeline: {self.init_pipeline.structure} \n'
+                         f'Initial metric: {abs(self.init_metric):.3f}')
 
     def final_check(self, tuned_pipeline: Pipeline):
         """
@@ -112,13 +114,16 @@ class HyperoptTuner(ABC):
         init_metric = self.init_metric + deviation * np.sign(self.init_metric)
         if self.obtained_metric is None:
             self.log.info(f'{prefix_init_phrase} is None. Initial metric is {abs(init_metric):.3f}')
-            return self.init_pipeline
+            final_pipeline = self.init_pipeline
 
         elif self.obtained_metric <= init_metric:
             self.log.info(f'{prefix_tuned_phrase} {abs(self.obtained_metric):.3f} equal or '
                           f'better than initial (+ 5% deviation) {abs(init_metric):.3f}')
-            return tuned_pipeline
+            final_pipeline = tuned_pipeline
         else:
             self.log.info(f'{prefix_init_phrase} {abs(self.obtained_metric):.3f} '
                           f'worse than initial (+ 5% deviation) {abs(init_metric):.3f}')
-            return self.init_pipeline
+            final_pipeline = self.init_pipeline
+        self.log.message(f'Final pipeline: {final_pipeline.structure} \n'
+                         f'Final metric: {abs(self.obtained_metric):.3f}')
+        return final_pipeline

--- a/fedot/core/pipelines/tuning/unified.py
+++ b/fedot/core/pipelines/tuning/unified.py
@@ -4,7 +4,7 @@ from typing import Tuple
 from hyperopt import fmin, space_eval, hp, Trials
 
 from fedot.core.pipelines.pipeline import Pipeline
-from fedot.core.pipelines.tuning.search_space import convert_params
+from fedot.core.pipelines.tuning.search_space import convert_params, get_node_operation_parameter_label
 from fedot.core.pipelines.tuning.tuner_interface import HyperoptTuner
 
 
@@ -19,6 +19,7 @@ class PipelineTuner(HyperoptTuner):
         :param pipeline: Pipeline which hyperparameters will be tuned
         :param show_progress: shows progress of tuning if true
         """
+
         parameters_dict, init_parameters, is_init_params_full = self._get_parameters_for_tune(pipeline)
         self.init_check(pipeline)
 
@@ -26,6 +27,7 @@ class PipelineTuner(HyperoptTuner):
 
         trials = Trials()
 
+        # try searching using initial parameters (uses original search space with fixed initial parameters)
         try_initial_parameters = init_parameters and self.iterations > 1
 
         if try_initial_parameters:
@@ -42,8 +44,10 @@ class PipelineTuner(HyperoptTuner):
                     early_stop_fn=self.early_stop_fn,
                     timeout=self.max_seconds)
 
+        # check if best point was obtained using search space with fixed initial parameters
         if try_initial_parameters:
             is_best_trial_with_init_params = trials.best_trial.get('tid') in range(init_trials_num)
+            # replace search space
             parameters_dict = init_parameters if is_best_trial_with_init_params else parameters_dict
 
         best = space_eval(space=parameters_dict, hp_assignment=best)
@@ -59,9 +63,12 @@ class PipelineTuner(HyperoptTuner):
     def _search_near_initial_parameters(self, pipeline: Pipeline, initial_parameters: dict,
                                         is_init_parameters_full: bool, trials: Trials,
                                         show_progress: bool = True):
-        init_trials_num = min(int(self.iterations * 0.1), 10) \
-            if (self.iterations >= 10 and not is_init_parameters_full) else 1
+        if self.iterations >= 10 and not is_init_parameters_full:
+            init_trials_num = min(int(self.iterations * 0.1), 10)
+        else:
+            init_trials_num = 1
 
+        # fmin updates trials with evaluation points tried out during the call
         fmin(partial(self._objective, pipeline=pipeline),
              initial_parameters,
              trials=trials,
@@ -93,8 +100,8 @@ class PipelineTuner(HyperoptTuner):
                 parameters_dict.update(node_params)
 
             tunable_node_params = self.search_space.get_operation_parameter_range(operation_name)
-            tunable_initial_params = {f'{node_id} || {operation_name} | {p}':
-                                          node.parameters[p] for p in node.parameters if p in tunable_node_params}
+            tunable_initial_params = {get_node_operation_parameter_label(node_id, operation_name, p):
+                                      node.parameters[p] for p in node.parameters if p in tunable_node_params}
             if tunable_initial_params:
                 initial_parameters.update(tunable_initial_params)
 
@@ -105,6 +112,7 @@ class PipelineTuner(HyperoptTuner):
             for key in parameters_dict:
                 if key in initial_parameters:
                     value = initial_parameters[key]
+                    # fix possible value for initial parameter (the value will be chosen with probability=1)
                     init_params_space[key] = hp.pchoice(key, [(1, value)])
                 else:
                     init_params_space[key] = parameters_dict[key]

--- a/test/unit/pipelines/tuning/test_pipeline_tuning.py
+++ b/test/unit/pipelines/tuning/test_pipeline_tuning.py
@@ -99,7 +99,7 @@ def get_complex_class_pipeline():
 def get_class_pipelines():
     simple_pipelines = [get_simple_class_pipeline(operation_type) for operation_type in get_class_operation_types()]
 
-    return simple_pipelines + [get_complex_class_pipeline()]
+    return [get_complex_class_pipeline()]
 
 
 def get_regr_operation_types():
@@ -128,7 +128,6 @@ def get_not_default_search_space():
         },
         'lgbmreg': {
             'min_samples_leaf': (hp.uniform, [1e-3, 0.5]),
-            'n_estimators': (hp.choice, [[100]]),
             'max_depth': (hp.choice, [[2.5, 3.5, 4.5]]),
             'learning_rate': (hp.choice, [[1e-3, 1e-2, 1e-1]]),
             'subsample': (hp.uniform, [0.15, 1])
@@ -164,7 +163,7 @@ def run_pipeline_tuner(train_data,
                        search_space=SearchSpace(),
                        cv=None,
                        algo=tpe.suggest,
-                       iterations=1,
+                       iterations=10,
                        early_stopping_rounds=None):
     # Pipeline tuning
     pipeline_tuner = TunerBuilder(train_data.task) \
@@ -240,9 +239,7 @@ def test_custom_params_setter(data_fixture, request):
 
 
 @pytest.mark.parametrize('data_fixture, pipelines, loss_functions',
-                         [('regression_dataset', get_regr_pipelines(), get_regr_losses()),
-                          ('classification_dataset', get_class_pipelines(), get_class_losses()),
-                          ('multi_classification_dataset', get_class_pipelines(), get_class_losses())])
+                         [('classification_dataset', get_class_pipelines(), get_class_losses())])
 def test_pipeline_tuner_correct(data_fixture, pipelines, loss_functions, request):
     """ Test PipelineTuner for pipeline based on hyperopt library """
     data = request.getfixturevalue(data_fixture)
@@ -452,7 +449,7 @@ def test_search_space_correctness_after_customization():
 
 def test_search_space_get_operation_parameter_range():
     default_search_space = SearchSpace()
-    gbr_operations = ['n_estimators', 'loss', 'learning_rate', 'max_depth', 'min_samples_split',
+    gbr_operations = ['loss', 'learning_rate', 'max_depth', 'min_samples_split',
                       'min_samples_leaf', 'subsample', 'max_features', 'alpha']
 
     custom_search_space = {'gbr': {'max_depth': (hp.choice, [[3, 7, 31, 127, 8191, 131071]])}}

--- a/test/unit/pipelines/tuning/test_pipeline_tuning.py
+++ b/test/unit/pipelines/tuning/test_pipeline_tuning.py
@@ -99,7 +99,7 @@ def get_complex_class_pipeline():
 def get_class_pipelines():
     simple_pipelines = [get_simple_class_pipeline(operation_type) for operation_type in get_class_operation_types()]
 
-    return [get_complex_class_pipeline()]
+    return simple_pipelines + [get_complex_class_pipeline()]
 
 
 def get_regr_operation_types():
@@ -163,7 +163,7 @@ def run_pipeline_tuner(train_data,
                        search_space=SearchSpace(),
                        cv=None,
                        algo=tpe.suggest,
-                       iterations=10,
+                       iterations=1,
                        early_stopping_rounds=None):
     # Pipeline tuning
     pipeline_tuner = TunerBuilder(train_data.task) \
@@ -239,7 +239,9 @@ def test_custom_params_setter(data_fixture, request):
 
 
 @pytest.mark.parametrize('data_fixture, pipelines, loss_functions',
-                         [('classification_dataset', get_class_pipelines(), get_class_losses())])
+                         [('regression_dataset', get_regr_pipelines(), get_regr_losses()),
+                          ('classification_dataset', get_class_pipelines(), get_class_losses()),
+                          ('multi_classification_dataset', get_class_pipelines(), get_class_losses())])
 def test_pipeline_tuner_correct(data_fixture, pipelines, loss_functions, request):
     """ Test PipelineTuner for pipeline based on hyperopt library """
     data = request.getfixturevalue(data_fixture)


### PR DESCRIPTION
Now PipelineTuner considers initial parameters of a pipeline.  To achive that, at first search is conducted using search space with fixed initial parameters. After that search is continued on the whole initial search space.