### PR TITLE
Hotfix tuning with init params and some tests duration

### DIFF
--- a/fedot/core/pipelines/tuning/tuner_interface.py
+++ b/fedot/core/pipelines/tuning/tuner_interface.py
@@ -124,6 +124,9 @@ class HyperoptTuner(ABC):
             self.log.info(f'{prefix_init_phrase} {abs(self.obtained_metric):.3f} '
                           f'worse than initial (+ 5% deviation) {abs(init_metric):.3f}')
             final_pipeline = self.init_pipeline
-        self.log.message(f'Final pipeline: {final_pipeline.structure} \n'
-                         f'Final metric: {abs(self.obtained_metric):.3f}')
+        self.log.message(f'Final pipeline: {final_pipeline.structure}')
+        if self.obtained_metric is not None:
+            self.log.message(f'Final metric: {abs(self.obtained_metric):.3f}')
+        else:
+            self.log.message(f'Final metric is None')
         return final_pipeline

--- a/fedot/core/pipelines/tuning/tuner_interface.py
+++ b/fedot/core/pipelines/tuning/tuner_interface.py
@@ -38,7 +38,7 @@ class HyperoptTuner(ABC):
         self.init_metric = None
         self.obtained_metric = None
         self.objective_evaluate = objective_evaluate
-        self._default_metric_value = -MAX_METRIC_VALUE
+        self._default_metric_value = MAX_METRIC_VALUE
         self.search_space = search_space
         self.algo = algo
         self.n_jobs = n_jobs

--- a/fedot/core/pipelines/tuning/unified.py
+++ b/fedot/core/pipelines/tuning/unified.py
@@ -42,7 +42,6 @@ class PipelineTuner(HyperoptTuner):
                     timeout=self.max_seconds)
 
         best = space_eval(space=parameters_dict, hp_assignment=best)
-
         # check if best point was obtained using search space with fixed initial parameters
         is_best_trial_with_init_params = trials.best_trial.get('tid') in range(init_trials_num)
         if is_best_trial_with_init_params:
@@ -123,9 +122,8 @@ class PipelineTuner(HyperoptTuner):
         """
 
         # replace new parameters with parameters
-        unchangeable_parameters = unchangeable_parameters or {}
-        parameters_dict = {**parameters_dict, **unchangeable_parameters}
-
+        if unchangeable_parameters:
+            parameters_dict = {**parameters_dict, **unchangeable_parameters}
         # Set hyperparameters for every node
         pipeline = self.set_arg_pipeline(pipeline, parameters_dict)
         metric_value = self.get_metric_value(pipeline=pipeline)
@@ -145,7 +143,7 @@ class PipelineTuner(HyperoptTuner):
         # Set hyperparameters for every node
         for node_id, node in enumerate(pipeline.nodes):
             node_params = {key: value for key, value in parameters.items()
-                           if key.startswith(f'{str(node_id)}|{node.name}')}
+                           if key.startswith(f'{str(node_id)} || {node.name}')}
 
             if node_params is not None:
                 # Delete all prefix strings to get appropriate parameters names

--- a/fedot/core/pipelines/tuning/unified.py
+++ b/fedot/core/pipelines/tuning/unified.py
@@ -143,8 +143,9 @@ class PipelineTuner(HyperoptTuner):
             pipeline: pipeline with new hyperparameters in each node
         """
         # Set hyperparameters for every node
-        for node_id, _ in enumerate(pipeline.nodes):
-            node_params = {key: value for key, value in parameters.items() if key.startswith(str(node_id))}
+        for node_id, node in enumerate(pipeline.nodes):
+            node_params = {key: value for key, value in parameters.items()
+                           if key.startswith(f'{str(node_id)}|{node.name}')}
 
             if node_params is not None:
                 # Delete all prefix strings to get appropriate parameters names

--- a/test/unit/composer/test_composer.py
+++ b/test/unit/composer/test_composer.py
@@ -254,16 +254,18 @@ def dummy_quality_metric(*args, **kwargs):
 def test_gp_composer_with_adaptive_depth(data_fixture, request):
     data = request.getfixturevalue(data_fixture)
     dataset_to_compose = data
-    available_model_types = ['rf', 'knn']
+    available_secondary_model_types = ['rf', 'knn', 'logit', 'dt']
+    available_primary_model_types = available_secondary_model_types + ['scaling', 'resample']
 
     quality_metric = dummy_quality_metric
     max_depth = 5
     num_gen = 3
-    req = PipelineComposerRequirements(primary=available_model_types, secondary=available_model_types,
+    req = PipelineComposerRequirements(primary=available_primary_model_types, secondary=available_secondary_model_types,
                                        start_depth=2, max_depth=max_depth, num_of_generations=num_gen)
     params = GPGraphOptimizerParameters(adaptive_depth=True,
                                         adaptive_depth_max_stagnation=num_gen - 1,
-                                        genetic_scheme_type=GeneticSchemeTypesEnum.steady_state)
+                                        genetic_scheme_type=GeneticSchemeTypesEnum.steady_state,
+                                        pop_size=10)
     composer = ComposerBuilder(task=Task(TaskTypesEnum.classification)) \
         .with_requirements(req) \
         .with_optimizer_params(params) \

--- a/test/unit/composer/test_history.py
+++ b/test/unit/composer/test_history.py
@@ -154,7 +154,8 @@ def test_newly_generated_history(n_jobs: int):
                        timeout=None,
                        num_of_generations=num_of_gens, pop_size=3,
                        preset='fast_train',
-                       n_jobs=n_jobs)
+                       n_jobs=n_jobs,
+                       with_tuning=False)
     auto_model.fit(features=file_path_train, target='Y')
 
     history = auto_model.history

--- a/test/unit/optimizer/test_evaluation.py
+++ b/test/unit/optimizer/test_evaluation.py
@@ -38,8 +38,7 @@ def invalid_objective(pipeline: Pipeline) -> Fitness:
     'dispatcher',
     [SimpleDispatcher(PipelineAdapter()),
      MultiprocessingDispatcher(PipelineAdapter()),
-     MultiprocessingDispatcher(PipelineAdapter(), n_jobs=-1),
-     MultiprocessingDispatcher(PipelineAdapter(), n_jobs=1)]
+     MultiprocessingDispatcher(PipelineAdapter(), n_jobs=-1)]
 )
 def test_dispatchers_with_and_without_multiprocessing(dispatcher):
     _, population = set_up_tests()

--- a/test/unit/pipelines/tuning/test_pipeline_tuning.py
+++ b/test/unit/pipelines/tuning/test_pipeline_tuning.py
@@ -262,6 +262,21 @@ def test_pipeline_tuner_correct(data_fixture, pipelines, loss_functions, request
     assert is_tuning_finished
 
 
+def test_pipeline_tuner_with_initial_params(classification_dataset):
+    """ Test PipelineTuner based on hyperopt library for pipeline with initial parameters """
+    # a model
+    node = PrimaryNode(content={'name': 'xgboost', 'params': {'max_depth': 3,
+                                                              'learning_rate': 0.03,
+                                                              'min_child_weight': 2}})
+    pipeline = Pipeline(node)
+    pipeline_tuner, tuned_pipeline = run_pipeline_tuner(train_data=classification_dataset,
+                                                        pipeline=pipeline,
+                                                        loss_function=ClassificationMetricsEnum.ROCAUC,
+                                                        iterations=20)
+    assert pipeline_tuner.obtained_metric is not None
+    assert not tuned_pipeline.is_fitted
+
+
 @pytest.mark.parametrize('data_fixture, pipelines, loss_functions',
                          [('regression_dataset', get_regr_pipelines(), get_regr_losses()),
                           ('classification_dataset', get_class_pipelines(), get_class_losses()),

--- a/test/unit/validation/test_table_cv.py
+++ b/test/unit/validation/test_table_cv.py
@@ -134,7 +134,7 @@ def test_cv_api_correct():
                        'preset': 'fast_train',
                        'cv_folds': 2,
                        'show_progress': False,
-                       'timeout': 0.5}
+                       'timeout': 0.3}
     dataset_to_compose, dataset_to_validate = train_test_data_setup(get_classification_data())
     model = Fedot(problem='classification', logging_level=logging.INFO, **composer_params)
     fedot_model = model.fit(features=dataset_to_compose)


### PR DESCRIPTION
The problem was with the way initial parameters were fixed in search space. When in search space a parameter had hp.loguniform distribution the evaluation was failing if the parameter was fixed using hp.choice((1, fixed_value)). 
Now search space is not modified, we just do not change initial parameters for some first iterations of tuning.

Some test were taking too much time so they were fixed to execute faster.  