### PR TITLE
Fix metric deviation

### DIFF
--- a/fedot/core/pipelines/tuning/tuner_interface.py
+++ b/fedot/core/pipelines/tuning/tuner_interface.py
@@ -109,24 +109,26 @@ class HyperoptTuner(ABC):
         prefix_tuned_phrase = 'Return tuned pipeline due to the fact that obtained metric'
         prefix_init_phrase = 'Return init pipeline due to the fact that obtained metric'
 
-        # 5% deviation is acceptable
-        deviation = (self.init_metric / 100.0) * 5
-        init_metric = self.init_metric + deviation * np.sign(self.init_metric)
+        # 0.05% deviation is acceptable
+        deviation = (self.init_metric / 100.0) * 0.05
+        init_metric = self.init_metric + deviation * (-np.sign(self.init_metric))
         if self.obtained_metric is None:
             self.log.info(f'{prefix_init_phrase} is None. Initial metric is {abs(init_metric):.3f}')
             final_pipeline = self.init_pipeline
-
+            final_metric = self.init_metric
         elif self.obtained_metric <= init_metric:
             self.log.info(f'{prefix_tuned_phrase} {abs(self.obtained_metric):.3f} equal or '
-                          f'better than initial (+ 5% deviation) {abs(init_metric):.3f}')
+                          f'better than initial (+ 0.05% deviation) {abs(init_metric):.3f}')
             final_pipeline = tuned_pipeline
+            final_metric = self.obtained_metric
         else:
             self.log.info(f'{prefix_init_phrase} {abs(self.obtained_metric):.3f} '
-                          f'worse than initial (+ 5% deviation) {abs(init_metric):.3f}')
+                          f'worse than initial (+ 0.05% deviation) {abs(init_metric):.3f}')
             final_pipeline = self.init_pipeline
+            final_metric = self.init_metric
         self.log.message(f'Final pipeline: {final_pipeline.structure}')
-        if self.obtained_metric is not None:
-            self.log.message(f'Final metric: {abs(self.obtained_metric):.3f}')
+        if final_metric is not None:
+            self.log.message(f'Final metric: {abs(final_metric):.3f}')
         else:
             self.log.message(f'Final metric is None')
         return final_pipeline


### PR DESCRIPTION
Sign of metric deviation is now correct. Deviation is changed from 5% to 0.05% - so if ```obtained_metric <= 100.05% * initial_metric``` we return tuned pipeline.