### PR TITLE
Mark numpy 1.24.0 as non-compatible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Data
-numpy>=1.16.*
+numpy>=1.16.*, !=1.24.0
 pandas>=1.1.0, <1.3.0; python_version == '3.7'
 pandas>=1.3.0; python_version >='3.8'
 


### PR DESCRIPTION
According to this PR, Seaborn is not compatible with NumPy 1.24.0 due to a bug in the latter:

https://github.com/mwaskom/seaborn/pull/3194

Furthermore, the bug is going to be fixed by numpy 1.24.1:

https://github.com/numpy/numpy/milestone/114

Thus, restricting the bugged NumPy version only.