### PR TITLE
Fix plot_pareto

### DIFF
--- a/examples/simple/time_series_forecasting/api_forecasting.py
+++ b/examples/simple/time_series_forecasting/api_forecasting.py
@@ -5,8 +5,6 @@ import pandas as pd
 from fedot.api.main import Fedot
 from fedot.core.data.data import InputData
 from fedot.core.data.data_split import train_test_data_setup
-from fedot.core.pipelines.node import PrimaryNode, SecondaryNode
-from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.tasks import TsForecastingParams, Task, TaskTypesEnum
 from fedot.core.utils import fedot_project_root

--- a/fedot/api/api_utils/api_composer.py
+++ b/fedot/api/api_utils/api_composer.py
@@ -46,6 +46,7 @@ class ApiComposer:
         self.preprocessing_cache: Optional[PreprocessingCache] = None
         self.preset_name = None
         self.timer = None
+        self.metric_names = None
         # status flag indicating that composer step was applied
         self.was_optimised = False
         # status flag indicating that tuner step was applied
@@ -289,6 +290,8 @@ class ApiComposer:
             .with_cache(self.pipelines_cache, self.preprocessing_cache) \
             .with_graph_generation_param(graph_generation_params=graph_generation_params) \
             .build()
+
+        self.metric_names = gp_composer.optimizer.objective.metric_names
 
         n_jobs = determine_n_jobs(composer_requirements.n_jobs)
 

--- a/fedot/api/api_utils/params.py
+++ b/fedot/api/api_utils/params.py
@@ -116,7 +116,7 @@ class ApiParams:
             input_params['task_params'] = TsForecastingParams(forecast_length=DEFAULT_FORECAST_LENGTH)
 
         if self.api_params['problem'] == 'clustering':
-            raise ValueError('This type of task is not not supported in API now')
+            raise ValueError('This type of task is not supported in API now')
 
         self.task = self.get_task_params(self.api_params['problem'], input_params['task_params'])
         self.metric_name = self.get_default_metric(self.api_params['problem'])

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -435,7 +435,7 @@ class Fedot:
 
         Args:
             target: the array with target values of test data. If None target specified for fit is used
-            metric_names: the names of required metrics. If None metrics specified while initialisation are used
+            metric_names: the names of required metrics.
             in_sample: used for time-series forecasting.
                 If True prediction will be obtained as ``.predict(..., in_sample=True)``.
             validation_blocks: number of validation blocks for in-sample forecast.

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -1,6 +1,6 @@
 import logging
 from copy import deepcopy
-from typing import Any, List, Optional, Sequence, Tuple, Union
+from typing import Any, List, Optional, Sequence, Tuple, Union, Callable
 
 import numpy as np
 import pandas as pd
@@ -392,7 +392,7 @@ class Fedot:
         self.data_processor.preprocessor = self.current_pipeline.preprocessor
 
     def plot_pareto(self):
-        metric_names = self.params.metric_to_compose
+        metric_names = self.api_composer.metric_names
         # archive_history stores archives of the best models.
         # Each archive is sorted from the best to the worst model,
         # so the best_candidates is sorted too.
@@ -434,12 +434,12 @@ class Fedot:
         """Gets quality metrics for the fitted graph
 
         Args:
-            target: the array with target values of test data
-            metric_names: the names of required metrics
+            target: the array with target values of test data. If None target specified for fit is used
+            metric_names: the names of required metrics. If None metrics specified while initialisation are used
             in_sample: used for time-series forecasting.
                 If True prediction will be obtained as ``.predict(..., in_sample=True)``.
             validation_blocks: number of validation blocks for in-sample forecast.
-                If ``validation_blocks = None`` uses number of validation blocks set during model initialization
+                If None uses number of validation blocks set during model initialisation
                 (default is 2).
 
         Returns:
@@ -458,7 +458,6 @@ class Fedot:
             else:
                 self.test_data.target = target[:len(self.prediction.predict)]
 
-        # TODO change to sklearn metrics
         metric_names = ensure_wrapped_in_sequence(metric_names)
 
         calculated_metrics = dict()
@@ -478,15 +477,15 @@ class Fedot:
                                                       validation_blocks=validation_blocks)
                 real = deepcopy(self.test_data)
 
-                # Work inplace - correct predictions
-                self.data_processor.correct_predictions(real=real,
-                                                        prediction=prediction)
+            # Work inplace - correct predictions
+            self.data_processor.correct_predictions(real=real,
+                                                    prediction=prediction)
 
-                real.target = np.ravel(real.target)
+            real.target = np.ravel(real.target)
 
-                metric_value = abs(metric_cls.metric(reference=real,
-                                                     predicted=prediction))
-                calculated_metrics[metric_name] = round(metric_value, 3)
+            metric_value = abs(metric_cls.metric(reference=real,
+                                                 predicted=prediction))
+            calculated_metrics[metric_name] = round(metric_value, 3)
 
         return calculated_metrics
 

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -477,15 +477,15 @@ class Fedot:
                                                       validation_blocks=validation_blocks)
                 real = deepcopy(self.test_data)
 
-            # Work inplace - correct predictions
-            self.data_processor.correct_predictions(real=real,
-                                                    prediction=prediction)
+                # Work inplace - correct predictions
+                self.data_processor.correct_predictions(real=real,
+                                                        prediction=prediction)
 
-            real.target = np.ravel(real.target)
+                real.target = np.ravel(real.target)
 
-            metric_value = abs(metric_cls.metric(reference=real,
-                                                 predicted=prediction))
-            calculated_metrics[metric_name] = round(metric_value, 3)
+                metric_value = abs(metric_cls.metric(reference=real,
+                                                     predicted=prediction))
+                calculated_metrics[metric_name] = round(metric_value, 3)
 
         return calculated_metrics
 

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -434,7 +434,7 @@ class Fedot:
         """Gets quality metrics for the fitted graph
 
         Args:
-            target: the array with target values of test data. If None target specified for fit is used
+            target: the array with target values of test data. If None, target specified for fit is used
             metric_names: the names of required metrics.
             in_sample: used for time-series forecasting.
                 If True prediction will be obtained as ``.predict(..., in_sample=True)``.


### PR DESCRIPTION
plot_pareto was using ApiParams.metric_to_compose attribute which was not set anywere. Now metric names are obtained from api_composer.

This solution might be refactored after closing #1038

![Figure_1](https://user-images.githubusercontent.com/43475193/217544261-21279439-6555-4129-9041-edab924ebf22.png)
