### PR TITLE
Fix initial assumptions as list of pipelines

### DIFF
--- a/test/unit/api/test_api_params.py
+++ b/test/unit/api/test_api_params.py
@@ -79,11 +79,9 @@ def test_correctly_sets_default_params(input_params):
             assert output_params[k] == input_params[k]
 
 
-@pytest.mark.parametrize('input_params, case, correct_keys',
-                         [(fedot_params_full, 'composer', correct_composer_attributes),
-                          (params_with_missings, 'composer', correct_composer_attributes),
-                          (fedot_params_full, 'gp_algo', correct_gp_algorithm_attributes),
-                          (params_with_missings, 'gp_algo', correct_gp_algorithm_attributes)])
+@pytest.mark.parametrize('input_params', [fedot_params_full, params_with_missings])
+@pytest.mark.parametrize('case, correct_keys', [('composer', correct_composer_attributes),
+                                                ('gp_algo', correct_gp_algorithm_attributes)])
 def test_filter_params_correctly(input_params, case, correct_keys):
     params_repository = get_api_params_repository()
     input_params = params_repository.check_and_set_default_params(input_params)

--- a/test/unit/composer/test_history.py
+++ b/test/unit/composer/test_history.py
@@ -1,10 +1,14 @@
 import os
-from functools import partial
 from itertools import chain
 from pathlib import Path
 
 import numpy as np
 import pytest
+from golem.core.dag.graph import Graph
+from golem.core.optimisers.fitness import SingleObjFitness
+from golem.core.optimisers.genetic.evaluation import MultiprocessingDispatcher
+from golem.core.optimisers.opt_history_objects.individual import Individual
+from golem.core.optimisers.opt_history_objects.opt_history import OptHistory
 
 from fedot.api.main import Fedot
 from fedot.core.data.data import InputData
@@ -18,11 +22,6 @@ from fedot.core.pipelines.pipeline_graph_generation_params import get_pipeline_g
 from fedot.core.repository.quality_metrics_repository import ClassificationMetricsEnum, \
     RegressionMetricsEnum, MetricType
 from fedot.core.utils import fedot_project_root
-from golem.core.dag.graph import Graph
-from golem.core.optimisers.fitness import SingleObjFitness
-from golem.core.optimisers.genetic.evaluation import MultiprocessingDispatcher
-from golem.core.optimisers.opt_history_objects.individual import Individual
-from golem.core.optimisers.opt_history_objects.opt_history import OptHistory
 from test.unit.tasks.test_forecasting import get_ts_data
 from test.unit.validation.test_table_cv import get_classification_data
 

--- a/test/unit/composer/test_history.py
+++ b/test/unit/composer/test_history.py
@@ -86,7 +86,7 @@ def test_newly_generated_history(n_jobs: int):
     assert history is not None
     assert len(history.individuals) == num_of_gens + 2  # initial_assumptions + num_of_gens + final_choices
     assert len(history.archive_history) == num_of_gens + 2  # initial_assumptions + num_of_gens + final_choices
-    assert len(history.initial_assumptions) == 1
+    assert len(history.initial_assumptions) >= 2
     assert len(history.final_choices) == 1
     assert isinstance(history.tuning_result, Graph)
     _test_individuals_in_history(history)


### PR DESCRIPTION
`Fedot(..., initial_assumption=...)` is expected to get a sequence of pipelines and pass them as initial graphs to an optimizer via composer.

Moreover, FEDOT itself generates more than one initial assumption by default.

As the result of this bug, composer passed only one of the initial assumptions to an optimizer.

This PR fixes the bug and adds the corresponding test. 