### PR TITLE
Add catboost to default initial assumptions

### DIFF
--- a/examples/advanced/multimodal_text_num_example.py
+++ b/examples/advanced/multimodal_text_num_example.py
@@ -32,7 +32,7 @@ def run_multi_modal_example(file_path: str, visualization=False, with_tuning=Tru
                      target=fit_data.target)
 
     prediction = automl_model.predict(predict_data)
-    metrics = automl_model.get_metrics()
+    metrics = automl_model.get_metrics(metric_names='f1')
 
     if visualization:
         automl_model.current_pipeline.show()

--- a/examples/advanced/multimodal_text_num_example.py
+++ b/examples/advanced/multimodal_text_num_example.py
@@ -31,7 +31,7 @@ def run_multi_modal_example(file_path: str, visualization=False, with_tuning=Tru
     automl_model.fit(features=fit_data,
                      target=fit_data.target)
 
-    prediction = automl_model.predict(predict_data)
+    _ = automl_model.predict(predict_data)
     metrics = automl_model.get_metrics(metric_names='f1')
 
     if visualization:

--- a/fedot/api/api_utils/assumptions/task_assumptions.py
+++ b/fedot/api/api_utils/assumptions/task_assumptions.py
@@ -105,6 +105,7 @@ class ClassificationAssumptions(TaskAssumptions):
         return {
             'rf': PipelineBuilder().add_node('rf'),
             'logit': PipelineBuilder().add_node('logit'),
+            'catboost': PipelineBuilder().add_node('catboost'),
         }
 
     def ensemble_operation(self) -> str:

--- a/fedot/core/pipelines/tuning/search_space.py
+++ b/fedot/core/pipelines/tuning/search_space.py
@@ -259,8 +259,7 @@ class PipelineSearchSpace(SearchSpace):
                 'learning_rate': (hp.loguniform, [np.log(0.01), np.log(0.2)]),
                 'min_data_in_leaf': (hp.qloguniform, [0, 6, 1]),
                 'border_count': (hp.uniformint, [2, 255]),
-                'l2_leaf_reg': (hp.loguniform, [np.log(1e-8), np.log(10)]),
-                'loss_function': (hp.choice, [['Logloss', 'CrossEntropy']])
+                'l2_leaf_reg': (hp.loguniform, [np.log(1e-8), np.log(10)])
             },
             'catboostreg': {
                 'max_depth': (hp.uniformint, [1, 11]),


### PR DESCRIPTION
Added CatBoost to FEDOT initial assumptions for classification.

For the sake of stability, restricted tuning of the model's loss function.