### PR TITLE
1110 integration tests fix

### DIFF
--- a/cases/credit_scoring/credit_scoring_problem.py
+++ b/cases/credit_scoring/credit_scoring_problem.py
@@ -1,19 +1,12 @@
 import logging
-import os
-import random
-from pathlib import Path
 
-import numpy as np
 from sklearn.metrics import roc_auc_score as roc_auc
 
 from fedot.api.main import Fedot
-from fedot.core.constants import BEST_QUALITY_PRESET_NAME
 from fedot.core.data.data import InputData
 from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.utils import fedot_project_root
-
-random.seed(1)
-np.random.seed(1)
+from fedot.core.utils import set_random_seed
 
 
 def calculate_validation_metric(pipeline: Pipeline, dataset_to_validate: InputData) -> float:
@@ -32,16 +25,15 @@ def run_credit_scoring_problem(train_file_path, test_file_path,
                                **composer_args):
     automl = Fedot(problem='classification',
                    timeout=timeout,
-                   preset=BEST_QUALITY_PRESET_NAME,
-                   logging_level=logging.DEBUG,
+                   preset='fast_train',
+                   logging_level=logging.FATAL,
                    **composer_args)
     automl.fit(train_file_path, target=target)
     automl.predict(test_file_path)
     metrics = automl.get_metrics()
 
-    if automl.history:
-        lb = automl.history.get_leaderboard()
-        Path(os.path.join('D:/', "leaderboard.csv")).write_text(lb)
+    if automl.history and automl.history.generations:
+        print(automl.history.get_leaderboard())
 
     if visualization:
         automl.current_pipeline.show()
@@ -57,16 +49,18 @@ def get_scoring_data():
     # a dataset that will be used as a train and test set during composition
 
     file_path_train = 'cases/data/scoring/scoring_train.csv'
-    full_path_train = os.path.join(str(fedot_project_root()), file_path_train)
+    full_path_train = fedot_project_root().joinpath(file_path_train)
 
     # a dataset for a final validation of the composed model
     file_path_test = 'cases/data/scoring/scoring_test.csv'
-    full_path_test = os.path.join(str(fedot_project_root()), file_path_test)
+    full_path_test = fedot_project_root().joinpath(file_path_test)
 
     return full_path_train, full_path_test
 
 
 if __name__ == '__main__':
+    set_random_seed(42)
+
     full_path_train, full_path_test = get_scoring_data()
     run_credit_scoring_problem(full_path_train,
                                full_path_test,

--- a/cases/credit_scoring/credit_scoring_problem_multiobj.py
+++ b/cases/credit_scoring/credit_scoring_problem_multiobj.py
@@ -1,13 +1,9 @@
 import datetime
-import random
 
-import numpy as np
 from golem.core.optimisers.genetic.gp_params import GPAlgorithmParameters
 from golem.core.optimisers.genetic.operators.inheritance import GeneticSchemeTypesEnum
 from golem.core.optimisers.genetic.operators.selection import SelectionTypesEnum
 from golem.core.tuning.sequential import SequentialTuner
-
-from fedot.core.pipelines.pipeline_composer_requirements import PipelineComposerRequirements
 from golem.visualisation.opt_viz_extra import OptHistoryExtraVisualizer
 from sklearn.metrics import roc_auc_score as roc_auc
 
@@ -16,13 +12,12 @@ from fedot.core.composer.composer_builder import ComposerBuilder
 from fedot.core.data.data import InputData
 from fedot.core.pipelines.node import PipelineNode
 from fedot.core.pipelines.pipeline import Pipeline
+from fedot.core.pipelines.pipeline_composer_requirements import PipelineComposerRequirements
 from fedot.core.pipelines.tuning.tuner_builder import TunerBuilder
 from fedot.core.repository.operation_types_repository import get_operations_for_task
 from fedot.core.repository.quality_metrics_repository import ClassificationMetricsEnum, ComplexityMetricsEnum
 from fedot.core.repository.tasks import Task, TaskTypesEnum
-
-random.seed(12)
-np.random.seed(12)
+from fedot.core.utils import set_random_seed
 
 
 def results_visualization(history, composed_pipelines):
@@ -55,7 +50,7 @@ def run_credit_scoring_problem(train_file_path, test_file_path,
 
     # the choice of the metric for the pipeline quality assessment during composition
     quality_metric = ClassificationMetricsEnum.ROCAUC
-    complexity_metric = ComplexityMetricsEnum.node_num
+    complexity_metric = ComplexityMetricsEnum.node_number
     metrics = [quality_metric, complexity_metric]
     # the choice and initialisation of the GP search
     composer_requirements = PipelineComposerRequirements(
@@ -70,11 +65,13 @@ def run_credit_scoring_problem(train_file_path, test_file_path,
     )
 
     # Create composer and with required composer params
-    composer = ComposerBuilder(task=task). \
-        with_optimizer_params(params). \
-        with_requirements(composer_requirements). \
-        with_metrics(metrics). \
-        build()
+    composer = (
+        ComposerBuilder(task=task)
+        .with_optimizer_params(params)
+        .with_requirements(composer_requirements)
+        .with_metrics(metrics)
+        .build()
+    )
 
     # the optimal pipeline generation by composition - the most time-consuming task
     pipelines_evo_composed = composer.compose_pipeline(data=dataset_to_compose)
@@ -88,11 +85,13 @@ def run_credit_scoring_problem(train_file_path, test_file_path,
 
     for pipeline_num, pipeline_evo_composed in enumerate(pipelines_evo_composed):
 
-        tuner = TunerBuilder(task)\
-            .with_tuner(SequentialTuner)\
-            .with_iterations(50)\
-            .with_metric(metrics[0])\
+        tuner = (
+            TunerBuilder(task)
+            .with_tuner(SequentialTuner)
+            .with_iterations(50)
+            .with_metric(metrics[0])
             .build(dataset_to_compose)
+        )
         nodes = pipeline_evo_composed.nodes
         for node_index, node in enumerate(nodes):
             if isinstance(node, PipelineNode) and node.is_primary:
@@ -115,5 +114,7 @@ def run_credit_scoring_problem(train_file_path, test_file_path,
 
 
 if __name__ == '__main__':
+    set_random_seed(12)
+
     full_path_train, full_path_test = get_scoring_data()
     run_credit_scoring_problem(full_path_train, full_path_test, visualization=True)

--- a/cases/metocean_forecasting_problem.py
+++ b/cases/metocean_forecasting_problem.py
@@ -44,7 +44,7 @@ def run_metocean_forecasting_problem(train_file_path, test_file_path,
 
     fedot = Fedot(problem='ts_forecasting',
                   task_params=TsForecastingParams(forecast_length=forecast_length),
-                  timeout=timeout, logging_level=logging.DEBUG)
+                  timeout=timeout, logging_level=logging.FATAL)
 
     pipeline = fedot.fit(features=historical_data, target=ssh_history)
     fedot.forecast(historical_data)

--- a/docs/source/advanced/cli_call.rst
+++ b/docs/source/advanced/cli_call.rst
@@ -56,7 +56,6 @@ The result of execution is presented below:
                         Composer parameter: model names to use
   --tuning TUNING       Composer parameter: 1 - with tuning, 0 - without tuning
   --cv_folds CV_FOLDS   Composer parameter: Number of folds for cross-validation
-  --val_bl VAL_BL       Composer parameter: Number of validation blocks for time series forecasting
   --hist_path HIST_PATH
                         Composer parameter: Name of the folder for composing history
   --for_len FOR_LEN     Time Series Forecasting parameter: forecast length

--- a/examples/advanced/additional_learning.py
+++ b/examples/advanced/additional_learning.py
@@ -9,6 +9,7 @@ from fedot.core.pipelines.node import PipelineNode
 from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.pipelines.pipeline_builder import PipelineBuilder
 from fedot.core.utils import fedot_project_root
+from fedot.core.utils import set_random_seed
 
 
 def run_additional_learning_example():
@@ -22,7 +23,7 @@ def run_additional_learning_example():
 
     problem = 'classification'
 
-    auto_model = Fedot(problem=problem, seed=42, timeout=5, preset='best_quality',
+    auto_model = Fedot(problem=problem, timeout=5, preset='best_quality',
                        initial_assumption=PipelineBuilder().add_node('scaling').add_node('logit').build())
 
     auto_model.fit(features=deepcopy(train_data.head(1000)), target='target')
@@ -40,16 +41,16 @@ def run_additional_learning_example():
     train_data = train_data.head(5000)
     timeout = 1
 
-    auto_model_from_atomized = Fedot(problem=problem, seed=42, preset='best_quality', timeout=timeout,
-                                     logging_level=logging.INFO,
+    auto_model_from_atomized = Fedot(problem=problem, preset='best_quality', timeout=timeout,
+                                     logging_level=logging.FATAL,
                                      initial_assumption=atomized_model)
     auto_model_from_atomized.fit(features=deepcopy(train_data), target='target')
     auto_model_from_atomized.predict_proba(features=deepcopy(test_data))
     auto_model_from_atomized.current_pipeline.show()
     print('auto_model_from_atomized', auto_model_from_atomized.get_metrics(deepcopy(test_data_target)))
 
-    auto_model_from_pipeline = Fedot(problem=problem, seed=42, preset='best_quality', timeout=timeout,
-                                     logging_level=logging.INFO,
+    auto_model_from_pipeline = Fedot(problem=problem, preset='best_quality', timeout=timeout,
+                                     logging_level=logging.FATAL,
                                      initial_assumption=non_atomized_model)
     auto_model_from_pipeline.fit(features=deepcopy(train_data), target='target')
     auto_model_from_pipeline.predict_proba(features=deepcopy(test_data))
@@ -58,4 +59,6 @@ def run_additional_learning_example():
 
 
 if __name__ == '__main__':
+    set_random_seed(42)
+
     run_additional_learning_example()

--- a/examples/advanced/decompose/classification_refinement_example.py
+++ b/examples/advanced/decompose/classification_refinement_example.py
@@ -1,6 +1,3 @@
-import random
-
-import numpy as np
 from golem.core.tuning.simultaneous import SimultaneousTuner
 
 from cases.credit_scoring.credit_scoring_problem import get_scoring_data, calculate_validation_metric
@@ -10,9 +7,7 @@ from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.pipelines.tuning.tuner_builder import TunerBuilder
 from fedot.core.repository.quality_metrics_repository import ClassificationMetricsEnum
 from fedot.core.repository.tasks import Task, TaskTypesEnum
-
-random.seed(1)
-np.random.seed(1)
+from fedot.core.utils import set_random_seed
 
 
 def get_refinement_pipeline():
@@ -66,11 +61,13 @@ def run_refinement_scoring_example(train_path, test_path, with_tuning=False):
     display_roc_auc(decompose_c, test_dataset, 'With decomposition pipeline')
 
     if with_tuning:
-        tuner = TunerBuilder(task) \
-            .with_tuner(SimultaneousTuner)\
-            .with_metric(ClassificationMetricsEnum.ROCAUC)\
-            .with_iterations(30) \
+        tuner = (
+            TunerBuilder(task)
+            .with_tuner(SimultaneousTuner)
+            .with_metric(ClassificationMetricsEnum.ROCAUC)
+            .with_iterations(30)
             .build(train_dataset)
+        )
         no_decompose_c = tuner.tune(no_decompose_c)
         decompose_c = tuner.tune(decompose_c)
 
@@ -82,5 +79,7 @@ def run_refinement_scoring_example(train_path, test_path, with_tuning=False):
 
 
 if __name__ == '__main__':
+    set_random_seed(1)
+
     full_path_train, full_path_test = get_scoring_data()
     run_refinement_scoring_example(full_path_train, full_path_test, with_tuning=True)

--- a/examples/advanced/decompose/refinement_forecast_example.py
+++ b/examples/advanced/decompose/refinement_forecast_example.py
@@ -12,9 +12,10 @@ from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.pipelines.ts_wrappers import in_sample_ts_forecast
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.tasks import TaskTypesEnum, Task, TsForecastingParams
+from fedot.core.utils import set_random_seed
+
 
 warnings.filterwarnings('ignore')
-np.random.seed(2020)
 
 
 def get_refinement_pipeline_with_polyfit():
@@ -160,6 +161,8 @@ def run_refinement_forecast(path_to_file, len_forecast=100, lagged=150,
 
 
 if __name__ == '__main__':
+    set_random_seed(2020)
+
     path = '../../../cases/data/time_series/economic_data.csv'
     run_refinement_forecast(path, len_forecast=50, validation_blocks=5,
                             lagged=50, vis_with_decompose=True)

--- a/examples/advanced/fedot_based_solutions/external_optimizer.py
+++ b/examples/advanced/fedot_based_solutions/external_optimizer.py
@@ -13,7 +13,7 @@ def run_with_random_search_composer():
     composer_params = {'available_operations': ['class_decompose', 'rf', 'linear', 'xgboost', 'dt'],
                        'optimizer': RandomMutationSearchOptimizer}
 
-    automl = Fedot(problem='classification', timeout=1, logging_level=logging.DEBUG,
+    automl = Fedot(problem='classification', timeout=1, logging_level=logging.FATAL,
                    preset='fast_train', **composer_params)
 
     automl.fit(train_data_path)

--- a/examples/advanced/multimodal_text_num_example.py
+++ b/examples/advanced/multimodal_text_num_example.py
@@ -1,12 +1,12 @@
-from pathlib import Path
-
 from fedot.api.main import Fedot
 from fedot.core.data.data_split import train_test_data_setup
 from fedot.core.data.multi_modal import MultiModalData
 from fedot.core.utils import fedot_project_root
+from fedot.core.utils import set_random_seed
 
 
-def run_multi_modal_example(file_path: str, visualization=False, with_tuning=True) -> float:
+def run_multi_modal_example(file_path: str, visualization: bool = False, with_tuning: bool = True,
+                            timeout: float = 10.) -> float:
     """
     Runs FEDOT on multimodal data from the `Wine Reviews dataset
     <https://www.kaggle.com/datasets/zynicide/wine-reviews>`_.
@@ -18,16 +18,17 @@ def run_multi_modal_example(file_path: str, visualization=False, with_tuning=Tru
         file_path: path to the file with multimodal data.
         visualization: if True, then final pipeline will be visualised.
         with_tuning: if True, then pipeline will be tuned.
+        timeout: overall fitting duration
 
     Returns:
         F1 metrics of the model.
     """
     task = 'classification'
-    path = Path(fedot_project_root(), file_path)
+    path = fedot_project_root().joinpath(file_path)
     data = MultiModalData.from_csv(file_path=path, task=task, target_columns='variety', index_col=None)
     fit_data, predict_data = train_test_data_setup(data, shuffle_flag=True, split_ratio=0.7)
 
-    automl_model = Fedot(problem=task, timeout=10, with_tuning=with_tuning)
+    automl_model = Fedot(problem=task, timeout=timeout, with_tuning=with_tuning, n_jobs=1)
     automl_model.fit(features=fit_data,
                      target=fit_data.target)
 
@@ -39,8 +40,10 @@ def run_multi_modal_example(file_path: str, visualization=False, with_tuning=Tru
 
     print(f'F1 for validation sample is {round(metrics["f1"], 3)}')
 
-    return metrics["f1"]
+    return metrics['f1']
 
 
 if __name__ == '__main__':
+    set_random_seed(42)
+
     run_multi_modal_example(file_path='examples/data/multimodal_wine.csv', visualization=True)

--- a/examples/advanced/multiobj_optimisation.py
+++ b/examples/advanced/multiobj_optimisation.py
@@ -2,6 +2,7 @@ import pandas as pd
 
 from fedot.api.main import Fedot
 from fedot.core.utils import fedot_project_root
+from fedot.core.utils import set_random_seed
 
 
 def run_classification_multiobj_example(visualization=False, timeout=1, with_tuning=True):
@@ -11,8 +12,8 @@ def run_classification_multiobj_example(visualization=False, timeout=1, with_tun
     del test_data['class']
     problem = 'classification'
 
-    metric_names = ['f1', 'node_num']
-    auto_model = Fedot(problem=problem, timeout=timeout, preset='best_quality', seed=42,
+    metric_names = ['f1', 'node_number']
+    auto_model = Fedot(problem=problem, timeout=timeout, preset='best_quality',
                        metric=metric_names,
                        with_tuning=with_tuning)
     auto_model.fit(features=train_data, target='class')
@@ -27,4 +28,6 @@ def run_classification_multiobj_example(visualization=False, timeout=1, with_tun
 
 
 if __name__ == '__main__':
+    set_random_seed(42)
+
     run_classification_multiobj_example(visualization=True)

--- a/examples/advanced/parallelization_comparison.py
+++ b/examples/advanced/parallelization_comparison.py
@@ -46,7 +46,7 @@ def run_experiments(timeout: float = None, partitions_n=10, n_jobs=-1):
             train_data_tmp = train_data.iloc[:partition].copy()
             start_time = timeit.default_timer()
             auto_model = Fedot(problem=problem, seed=42, timeout=timeout,
-                               n_jobs=_n_jobs, logging_level=logging.NOTSET,
+                               n_jobs=_n_jobs, logging_level=logging.FATAL,
                                with_tuning=False, preset='fast_train')
             auto_model.fit(features=train_data_tmp, target='target')
             times[_n_jobs].append((timeit.default_timer() - start_time) / 60)

--- a/examples/advanced/profiler_example.py
+++ b/examples/advanced/profiler_example.py
@@ -1,16 +1,14 @@
 import os
-import random
 
-import numpy as np
 from golem.utilities.profiler.memory_profiler import MemoryProfiler
 from golem.utilities.profiler.time_profiler import TimeProfiler
 
 from cases.credit_scoring.credit_scoring_problem import run_credit_scoring_problem, get_scoring_data
+from fedot.core.utils import set_random_seed
 
-random.seed(1)
-np.random.seed(1)
 
 if __name__ == '__main__':
+    set_random_seed(1)
     # JUST UNCOMMENT WHAT TYPE OF PROFILER DO YOU NEED
     # EXAMPLE of MemoryProfiler.
 

--- a/examples/advanced/remote_execution/remote_fit_example.py
+++ b/examples/advanced/remote_execution/remote_fit_example.py
@@ -1,63 +1,66 @@
 import os
-import random
 from datetime import datetime
-
-import numpy as np
 
 from fedot.core.data.data import InputData
 from fedot.core.pipelines.node import PipelineNode
 from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.utils import fedot_project_root
+from fedot.core.utils import set_random_seed
 from fedot.remote.infrastructure.clients.test_client import TestClient
 from fedot.remote.remote_evaluator import RemoteEvaluator, RemoteTaskParams
 
-random.seed(1)
-np.random.seed(1)
 
-num_parallel = 3  # NUMBER OF PARALLEL TASKS
+def run_experiment():
+    num_parallel = 3  # NUMBER OF PARALLEL TASKS
 
-# WARNING - THIS SCRIPT CAN BE EVALUATED ONLY WITH THE ACCESS TO DATAMALL SYSTEM
+    # WARNING - THIS SCRIPT CAN BE EVALUATED ONLY WITH THE ACCESS TO DATAMALL SYSTEM
 
-# LOCAL RUN
-folder = os.path.join(fedot_project_root(), 'cases', 'data', 'scoring')
-path = os.path.join(folder, 'scoring_train.csv')
+    # LOCAL RUN
+    folder = fedot_project_root().joinpath('cases', 'data', 'scoring')
+    path = folder.joinpath('scoring_train.csv')
 
-start = datetime.now()
-data = InputData.from_csv(path)
-data.subset_indices([1, 2, 3, 4, 5, 20])
-pipeline = Pipeline(PipelineNode('rf'))
-pipeline.fit_from_scratch(data)
-end = datetime.now()
+    start = datetime.now()
+    data = InputData.from_csv(path)
+    data.subset_indices([1, 2, 3, 4, 5, 20])
+    pipeline = Pipeline(PipelineNode('rf'))
+    pipeline.fit_from_scratch(data)
+    end = datetime.now()
 
-print('LOCAL EXECUTION TIME', end - start)
+    print('LOCAL EXECUTION TIME', end - start)
 
-# REMOTE RUN
+    # REMOTE RUN
 
-connect_params = {}
-exec_params = {
-    'container_input_path': folder,
-    'container_output_path': os.path.join(folder, 'remote'),
-    'container_config_path': ".",
-    'container_image': "test",
-    'timeout': 1
-}
+    connect_params = {}
+    exec_params = {
+        'container_input_path': folder,
+        'container_output_path': folder.joinpath('remote'),
+        'container_config_path': ".",
+        'container_image': "test",
+        'timeout': 1
+    }
 
-remote_task_params = RemoteTaskParams(
-    mode='remote',
-    dataset_name='scoring_train',
-    task_type='Task(TaskTypesEnum.classification)',
-    max_parallel=num_parallel
-)
+    remote_task_params = RemoteTaskParams(
+        mode='remote',
+        dataset_name='scoring_train',
+        task_type='Task(TaskTypesEnum.classification)',
+        max_parallel=num_parallel
+    )
 
-client = TestClient(connect_params, exec_params, output_path=os.path.join(folder, 'remote'))
+    client = TestClient(connect_params, exec_params, output_path=os.path.join(folder, 'remote'))
 
-evaluator = RemoteEvaluator()
-evaluator.init(
-    client=client,
-    remote_task_params=remote_task_params
-)
+    evaluator = RemoteEvaluator()
+    evaluator.init(
+        client=client,
+        remote_task_params=remote_task_params
+    )
 
-pipelines = [Pipeline(PipelineNode('rf'))] * num_parallel
-fitted_pipelines = evaluator.compute_graphs(pipelines)
+    pipelines = [Pipeline(PipelineNode('rf'))] * num_parallel
+    fitted_pipelines = evaluator.compute_graphs(pipelines)
 
-[print(p.is_fitted) for p in fitted_pipelines]
+    [print(p.is_fitted) for p in fitted_pipelines]
+
+
+if __name__ == '__main__':
+    set_random_seed(1)
+
+    run_experiment()

--- a/examples/advanced/remote_execution/ts_composer_with_integration.py
+++ b/examples/advanced/remote_execution/ts_composer_with_integration.py
@@ -1,16 +1,9 @@
-import os
-import random
-
-import numpy as np
-
 from fedot.api.main import Fedot
 from fedot.core.data.multi_modal import MultiModalData
 from fedot.core.utils import fedot_project_root
+from fedot.core.utils import set_random_seed
 from fedot.remote.infrastructure.clients.test_client import TestClient
 from fedot.remote.remote_evaluator import RemoteEvaluator, RemoteTaskParams
-
-random.seed(1)
-np.random.seed(1)
 
 
 # WARNING - THIS SCRIPT CAN BE EVALUATED ONLY WITH THE ACCESS TO DATAMALL SYSTEM
@@ -27,17 +20,17 @@ def run_automl(data: MultiModalData, features_to_use,
                timeout: int = 1):
     """ Launch AutoML FEDOT algorithm for time series forecasting task """
 
-    folder = os.path.join(fedot_project_root(), 'cases', 'data', 'metocean')
+    metocean_folder = fedot_project_root().joinpath('cases', 'data', 'metocean')
 
     connect_params = {}
     exec_params = {
-        'container_input_path': os.path.join(fedot_project_root(), 'cases', 'data', 'metocean'),
-        'container_output_path': os.path.join(fedot_project_root(), 'cases', 'data', 'metocean', 'remote'),
-        'container_config_path': os.path.join(fedot_project_root(), 'cases', 'data', 'metocean', '.'),
+        'container_input_path': metocean_folder,
+        'container_output_path': metocean_folder.joinpath('remote'),
+        'container_config_path': metocean_folder.joinpath('metocean', '.'),
         'container_image': "test",
         'timeout': 1
     }
-    client = TestClient(connect_params, exec_params, output_path=os.path.join(folder, 'remote'))
+    client = TestClient(connect_params, exec_params, output_path=metocean_folder.joinpath('remote'))
 
     remote_task_params = RemoteTaskParams(
         mode='remote',
@@ -74,17 +67,20 @@ def run_automl(data: MultiModalData, features_to_use,
     return forecast, obtained_pipeline
 
 
-features_to_use = ['wind_speed', 'sea_height']
+if __name__ == '__main__':
+    set_random_seed(1)
 
-data = MultiModalData.from_csv_time_series(
-    file_path=f'{fedot_project_root()}/cases/data/metocean/metocean_data_train.csv',
-    columns_to_use=features_to_use,
-    target_column='sea_height',
-    index_col='datetime')
+    features_to_use = ['wind_speed', 'sea_height']
 
-forecast, obtained_pipeline = run_automl(data=data, features_to_use=['wind_speed', 'sea_height'],
-                                         forecast_horizon=30,
-                                         history_size=200,
-                                         timeout=5)
+    data = MultiModalData.from_csv_time_series(
+        file_path=fedot_project_root().joinpath('cases/data/metocean/metocean_data_train.csv'),
+        columns_to_use=features_to_use,
+        target_column='sea_height',
+        index_col='datetime')
 
-obtained_pipeline.show()
+    forecast, obtained_pipeline = run_automl(data=data, features_to_use=['wind_speed', 'sea_height'],
+                                             forecast_horizon=30,
+                                             history_size=200,
+                                             timeout=5)
+
+    obtained_pipeline.show()

--- a/examples/advanced/time_series_forecasting/exogenous.py
+++ b/examples/advanced/time_series_forecasting/exogenous.py
@@ -1,4 +1,3 @@
-import os
 import timeit
 import warnings
 
@@ -15,9 +14,9 @@ from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.tasks import Task, TsForecastingParams, TaskTypesEnum
 from fedot.core.utils import fedot_project_root
+from fedot.core.utils import set_random_seed
 
 warnings.filterwarnings('ignore')
-np.random.seed(2020)
 
 
 def make_forecast(pipeline, train: InputData, predict: InputData,
@@ -73,18 +72,15 @@ def run_exogenous_experiment(path_to_file, len_forecast=250, with_exog=True,
     time_series = np.array(df['Level'])
     exog_variable = np.array(df['Neighboring level'])
 
+    task = Task(TaskTypesEnum.ts_forecasting, TsForecastingParams(forecast_length=len_forecast))
     # Source time series
     train_input, predict_input = train_test_data_setup(InputData(idx=range(len(time_series)),
                                                                  features=time_series,
                                                                  target=time_series,
-                                                                 task=Task(TaskTypesEnum.ts_forecasting,
-                                                                           TsForecastingParams(
-                                                                               forecast_length=len_forecast)),
+                                                                 task=task,
                                                                  data_type=DataTypesEnum.ts))
 
     # Exogenous time series
-    task = Task(TaskTypesEnum.ts_forecasting, TsForecastingParams(forecast_length=len_forecast))
-
     predict_input_exog = InputData(idx=np.arange(len(exog_variable)),
                                    features=exog_variable, target=time_series,
                                    task=task, data_type=DataTypesEnum.ts)
@@ -137,5 +133,7 @@ def run_exogenous_experiment(path_to_file, len_forecast=250, with_exog=True,
 
 
 if __name__ == '__main__':
-    data_path = os.path.join(f'{fedot_project_root()}', 'examples/data/ts', 'ts_sea_level.csv')
+    set_random_seed(2020)
+
+    data_path = fedot_project_root().joinpath('examples/data/ts', 'ts_sea_level.csv')
     run_exogenous_experiment(path_to_file=data_path, len_forecast=250, with_exog=True, visualization=True)

--- a/examples/advanced/time_series_forecasting/multistep.py
+++ b/examples/advanced/time_series_forecasting/multistep.py
@@ -1,31 +1,30 @@
-import os
 import warnings
 
 import numpy as np
 import pandas as pd
 
 from examples.advanced.time_series_forecasting.composing_pipelines import get_border_line_info
-from examples.simple.time_series_forecasting.ts_pipelines import *
+from examples.simple.time_series_forecasting.ts_pipelines import ts_ar_pipeline
 from examples.simple.time_series_forecasting.tuning_pipelines import visualise
 from fedot.core.data.data import InputData
 from fedot.core.data.data_split import train_test_data_setup
 from fedot.core.pipelines.pipeline import Pipeline
-
 from fedot.core.pipelines.ts_wrappers import out_of_sample_ts_forecast
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.tasks import TaskTypesEnum, Task, TsForecastingParams
-
 from fedot.core.utils import fedot_project_root
+from fedot.core.utils import set_random_seed
 
 warnings.filterwarnings('ignore')
-np.random.seed(2020)
 
-datasets = {
-    'australia': f'{fedot_project_root()}/examples/data/ts/australia.csv',
-    'beer': f'{fedot_project_root()}/examples/data/ts/beer.csv',
-    'salaries': f'{fedot_project_root()}/examples/data/ts/salaries.csv',
-    'stackoverflow': f'{fedot_project_root()}/examples/data/ts/stackoverflow.csv',
-    'test_sea': os.path.join(fedot_project_root(), 'test', 'data', 'simple_sea_level.csv')}
+_TS_EXAMPLES_DATA_PATH = fedot_project_root().joinpath('examples/data/ts')
+
+TS_DATASETS = {
+    'australia': _TS_EXAMPLES_DATA_PATH.joinpath('australia.csv'),
+    'beer': _TS_EXAMPLES_DATA_PATH.joinpath('beer.csv'),
+    'salaries': _TS_EXAMPLES_DATA_PATH.joinpath('salaries.csv'),
+    'stackoverflow': _TS_EXAMPLES_DATA_PATH.joinpath('stackoverflow.csv'),
+    'test_sea': fedot_project_root().joinpath('test', 'data', 'simple_sea_level.csv')}
 
 
 def run_multistep(dataset: str, pipeline: Pipeline, step_forecast: int = 10, future_steps: int = 5,
@@ -41,7 +40,7 @@ def run_multistep(dataset: str, pipeline: Pipeline, step_forecast: int = 10, fut
     pipeline.print_structure()
 
     horizon = step_forecast * future_steps
-    time_series = pd.read_csv(datasets[dataset])
+    time_series = pd.read_csv(TS_DATASETS[dataset])
     task = Task(TaskTypesEnum.ts_forecasting,
                 TsForecastingParams(forecast_length=step_forecast))
 
@@ -76,4 +75,6 @@ def run_multistep(dataset: str, pipeline: Pipeline, step_forecast: int = 10, fut
 
 
 if __name__ == '__main__':
+    set_random_seed(2020)
+
     run_multistep("australia", ts_ar_pipeline(), step_forecast=10, visualisation=True)

--- a/examples/simple/classification/api_classification.py
+++ b/examples/simple/classification/api_classification.py
@@ -1,5 +1,6 @@
 from fedot.api.main import Fedot
 from fedot.core.utils import fedot_project_root
+from fedot.core.utils import set_random_seed
 
 
 def run_classification_example(timeout: float = None, visualization=False, with_tuning=True):
@@ -7,13 +8,13 @@ def run_classification_example(timeout: float = None, visualization=False, with_
     train_data_path = f'{fedot_project_root()}/cases/data/scoring/scoring_train.csv'
     test_data_path = f'{fedot_project_root()}/cases/data/scoring/scoring_test.csv'
 
-    baseline_model = Fedot(problem=problem, timeout=timeout, seed=42)
+    baseline_model = Fedot(problem=problem, timeout=timeout)
     baseline_model.fit(features=train_data_path, target='target', predefined_model='rf')
 
     baseline_model.predict(features=test_data_path)
     print(baseline_model.get_metrics())
 
-    auto_model = Fedot(problem=problem, seed=42, timeout=timeout, n_jobs=-1, preset='best_quality',
+    auto_model = Fedot(problem=problem, timeout=timeout, n_jobs=-1, preset='best_quality',
                        max_pipeline_fit_time=5, metric='roc_auc', with_tuning=with_tuning)
     auto_model.fit(features=train_data_path, target='target')
     prediction = auto_model.predict_proba(features=test_data_path)
@@ -25,4 +26,6 @@ def run_classification_example(timeout: float = None, visualization=False, with_
 
 
 if __name__ == '__main__':
+    set_random_seed(42)
+
     run_classification_example(timeout=10.0, visualization=True)

--- a/examples/simple/classification/classification_with_tuning.py
+++ b/examples/simple/classification/classification_with_tuning.py
@@ -9,9 +9,8 @@ from fedot.core.pipelines.tuning.tuner_builder import TunerBuilder
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.quality_metrics_repository import ClassificationMetricsEnum
 from fedot.core.repository.tasks import Task, TaskTypesEnum
+from fedot.core.utils import set_random_seed
 from fedot.utilities.synth_dataset_generator import classification_dataset
-
-np.random.seed(2020)
 
 
 def get_classification_dataset(features_options, samples_amount=250,
@@ -119,11 +118,13 @@ def run_classification_tuning_experiment(pipeline, tuner=None):
 
         if tuner is not None:
             print('Start tuning process ...')
-            pipeline_tuner = TunerBuilder(task)\
-                .with_tuner(tuner)\
-                .with_metric(ClassificationMetricsEnum.ROCAUC)\
-                .with_iterations(50)\
+            pipeline_tuner = (
+                TunerBuilder(task)
+                .with_tuner(tuner)
+                .with_metric(ClassificationMetricsEnum.ROCAUC)
+                .with_iterations(50)
                 .build(train_input)
+            )
             tuned_pipeline = pipeline_tuner.tune(pipeline)
 
             # Fit it
@@ -140,5 +141,7 @@ def run_classification_tuning_experiment(pipeline, tuner=None):
 
 # Script for testing is pipeline can process different datasets for classification
 if __name__ == '__main__':
+    set_random_seed(2020)
+
     run_classification_tuning_experiment(pipeline=classification_random_forest_pipeline(),
                                          tuner=SimultaneousTuner)

--- a/examples/simple/classification/image_classification_problem.py
+++ b/examples/simple/classification/image_classification_problem.py
@@ -1,6 +1,3 @@
-import random
-
-import numpy as np
 from golem.utilities.requirements_notificator import warn_requirement
 
 try:
@@ -13,9 +10,7 @@ from sklearn.metrics import roc_auc_score as roc_auc
 from examples.simple.classification.classification_pipelines import cnn_composite_pipeline
 from fedot.core.data.data import InputData, OutputData
 from fedot.core.repository.tasks import Task, TaskTypesEnum
-
-random.seed(1)
-np.random.seed(1)
+from fedot.core.utils import set_random_seed
 
 
 def calculate_validation_metric(predicted: OutputData, dataset_to_validate: InputData) -> float:
@@ -50,6 +45,8 @@ def run_image_classification_problem(train_dataset: tuple,
 
 
 if __name__ == '__main__':
+    set_random_seed(1)
+
     training_set, testing_set = tf.keras.datasets.mnist.load_data(path='mnist.npz')
     roc_auc_on_valid, dataset_to_train, dataset_to_validate = run_image_classification_problem(
         train_dataset=training_set,

--- a/examples/simple/classification/multiclass_prediction.py
+++ b/examples/simple/classification/multiclass_prediction.py
@@ -1,18 +1,15 @@
 import datetime
 import os
-import random
 
 import pandas as pd
 from golem.utilities.requirements_notificator import warn_requirement
 
 try:
-    import openpyxl
+    import openpyxl  # noqa, later used via str parameter
 except ImportError:
     warn_requirement('openpyxl', 'fedot[examples]', should_raise=True)
 
 from datetime import timedelta
-
-import numpy as np
 
 from fedot.core.composer.composer_builder import ComposerBuilder
 from fedot.core.pipelines.pipeline_composer_requirements import PipelineComposerRequirements
@@ -30,9 +27,8 @@ from fedot.core.utils import (
     split_data
 )
 from sklearn.metrics import roc_auc_score as roc_auc
-
-random.seed(1)
-np.random.seed(1)
+from fedot.core.utils import set_random_seed
+from pathlib import Path
 
 
 def create_multi_clf_examples_from_excel(file_path: str, return_df: bool = False):
@@ -106,9 +102,12 @@ def validate_model_quality(model: Pipeline, data_path: str):
 
 
 if __name__ == '__main__':
-    file_path_first = r'../../data/example1.xlsx'
-    file_path_second = r'../../data/example2.xlsx'
-    file_path_third = r'../../data/example3.xlsx'
+    set_random_seed(1)
+
+    data_path = Path('../../data')
+    file_path_first = data_path.joinpath('example1.xlsx')
+    file_path_second = data_path.joinpath('example2.xlsx')
+    file_path_third = data_path.joinpath('example3.xlsx')
 
     train_file_path, test_file_path = create_multi_clf_examples_from_excel(file_path_first)
     test_data = InputData.from_csv(test_file_path)
@@ -117,8 +116,8 @@ if __name__ == '__main__':
 
     fitted_model.show()
 
-    roc_auc = validate_model_quality(fitted_model, test_file_path)
-    print(f'ROC AUC metric is {roc_auc}')
+    roc_auc_score = validate_model_quality(fitted_model, test_file_path)
+    print(f'ROC AUC metric is {roc_auc_score}')
 
     final_prediction_first = apply_model_to_data(fitted_model, file_path_second)
     print(final_prediction_first['forecast'])

--- a/examples/simple/pipeline_log.py
+++ b/examples/simple/pipeline_log.py
@@ -11,7 +11,7 @@ def run_log_example(log_file):
     train_data, _ = get_case_train_test_data()
 
     # Use default_log if you do not have json config file for log
-    log = Log(log_file=log_file, output_logging_level=logging.DEBUG).get_adapter(prefix=pathlib.Path(__file__).stem)
+    log = Log(log_file=log_file, output_logging_level=logging.FATAL).get_adapter(prefix=pathlib.Path(__file__).stem)
 
     log.info('start creating pipeline')
     pipeline = classification_complex_pipeline()

--- a/examples/simple/regression/api_regression.py
+++ b/examples/simple/regression/api_regression.py
@@ -7,7 +7,8 @@ from fedot.core.repository.tasks import TaskTypesEnum, Task
 from fedot.core.utils import fedot_project_root
 
 
-def run_regression_example(visualise=False, with_tuning=True):
+def run_regression_example(visualise: bool = False, with_tuning: bool = True,
+                           timeout: float = 2., preset: str = 'auto'):
     data_path = f'{fedot_project_root()}/cases/data/cholesterol/cholesterol.csv'
 
     data = InputData.from_csv(data_path,
@@ -15,8 +16,8 @@ def run_regression_example(visualise=False, with_tuning=True):
     train, test = train_test_data_setup(data)
     problem = 'regression'
 
-    composer_params = {'history_dir': 'custom_history_dir', 'preset': 'auto'}
-    auto_model = Fedot(problem=problem, seed=42, timeout=2, logging_level=logging.INFO,
+    composer_params = {'history_dir': 'custom_history_dir', 'preset': preset}
+    auto_model = Fedot(problem=problem, seed=42, timeout=timeout, logging_level=logging.FATAL,
                        with_tuning=with_tuning, **composer_params)
 
     auto_model.fit(features=train, target='target')

--- a/examples/simple/regression/regression_with_tuning.py
+++ b/examples/simple/regression/regression_with_tuning.py
@@ -11,9 +11,8 @@ from fedot.core.pipelines.tuning.tuner_builder import TunerBuilder
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.quality_metrics_repository import RegressionMetricsEnum
 from fedot.core.repository.tasks import Task, TaskTypesEnum
+from fedot.core.utils import set_random_seed
 from fedot.utilities.synth_dataset_generator import regression_dataset
-
-np.random.seed(2020)
 
 
 def get_regression_dataset(features_options, samples_amount=250,
@@ -100,12 +99,14 @@ def run_experiment(pipeline, tuner):
 
         if tuner is not None:
             print('Start tuning process ...')
-            pipeline_tuner = TunerBuilder(task)\
-                .with_tuner(tuner)\
-                .with_metric(RegressionMetricsEnum.MAE)\
-                .with_iterations(50) \
-                .with_timeout(timedelta(seconds=50))\
+            pipeline_tuner = (
+                TunerBuilder(task)
+                .with_tuner(tuner)
+                .with_metric(RegressionMetricsEnum.MAE)
+                .with_iterations(50)
+                .with_timeout(timedelta(seconds=50))
                 .build(train_input)
+            )
             tuned_pipeline = pipeline_tuner.tune(pipeline)
 
             # Fit it
@@ -125,4 +126,6 @@ def run_experiment(pipeline, tuner):
 
 # Script for testing is pipeline can process different datasets for regression task
 if __name__ == '__main__':
+    set_random_seed(2020)
+
     run_experiment(regression_ransac_pipeline(), tuner=SequentialTuner)

--- a/examples/simple/time_series_forecasting/api_forecasting.py
+++ b/examples/simple/time_series_forecasting/api_forecasting.py
@@ -2,24 +2,18 @@ import logging
 
 import pandas as pd
 
+from examples.advanced.time_series_forecasting.multistep import TS_DATASETS
 from fedot.api.main import Fedot
 from fedot.core.data.data import InputData
 from fedot.core.data.data_split import train_test_data_setup
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.tasks import TsForecastingParams, Task, TaskTypesEnum
-from fedot.core.utils import fedot_project_root
 
 logging.raiseExceptions = False
 
-datasets = {
-    'australia': f'{fedot_project_root()}/examples/data/ts/australia.csv',
-    'beer': f'{fedot_project_root()}/examples/data/ts/beer.csv',
-    'salaries': f'{fedot_project_root()}/examples/data/ts/salaries.csv',
-    'stackoverflow': f'{fedot_project_root()}/examples/data/ts/stackoverflow.csv'}
-
 
 def get_ts_data(dataset='australia', horizon: int = 30, validation_blocks=None):
-    time_series = pd.read_csv(datasets[dataset])
+    time_series = pd.read_csv(TS_DATASETS[dataset])
 
     task = Task(TaskTypesEnum.ts_forecasting,
                 TsForecastingParams(forecast_length=horizon))
@@ -44,7 +38,7 @@ def run_ts_forecasting_example(dataset='australia', horizon: int = 30, timeout: 
     # init model for the time series forecasting
     model = Fedot(problem='ts_forecasting',
                   task_params=Task(TaskTypesEnum.ts_forecasting,
-                TsForecastingParams(forecast_length=horizon)).task_params,
+                                   TsForecastingParams(forecast_length=horizon)).task_params,
                   timeout=timeout,
                   n_jobs=-1,
                   with_tuning=with_tuning,

--- a/fedot/api/api_utils/data_definition.py
+++ b/fedot/api/api_utils/data_definition.py
@@ -79,9 +79,12 @@ class PandasStrategy(StrategyDefineData):
         if target is None:
             target = np.array([])
 
-        if isinstance(target, str) and target in features.columns:
-            target_array = features[target]
-            features = features.drop(columns=target)
+        if isinstance(target, str):
+            if target in features.columns:
+                target_array = features[target]
+                features = features.drop(columns=target)
+            else:
+                target_array = np.array([])
         else:
             target_array = target
 
@@ -103,8 +106,11 @@ class NumpyStrategy(StrategyDefineData):
         if task.task_type is TaskTypesEnum.ts_forecasting:
             target_array = features
         elif isinstance(target, int):
-            target_array = features[target]
-            features = np.delete(features, target, axis=1)
+            if target < features.shape[1]:
+                target_array = features[:, target]
+                features = np.delete(features, target, axis=1)
+            else:
+                target_array = np.array([])
         else:
             target_array = target
 

--- a/fedot/api/api_utils/metrics.py
+++ b/fedot/api/api_utils/metrics.py
@@ -17,7 +17,7 @@ class ApiMetrics:
     """
 
     _metrics_dict = {
-        'acc': ClassificationMetricsEnum.accuracy,
+        'accuracy': ClassificationMetricsEnum.accuracy,
         'roc_auc': ClassificationMetricsEnum.ROCAUC,
         'f1': ClassificationMetricsEnum.f1,
         'logloss': ClassificationMetricsEnum.logloss,
@@ -30,7 +30,7 @@ class ApiMetrics:
         'rmse': RegressionMetricsEnum.RMSE,
         'rmse_pen': RegressionMetricsEnum.RMSE_penalty,
         'silhouette': ClusteringMetricsEnum.silhouette,
-        'node_num': ComplexityMetricsEnum.node_num
+        'node_number': ComplexityMetricsEnum.node_number
     }
 
     def __init__(self, task: Task, metrics: Optional[Union[str, MetricsEnum, Callable, Sequence]]):

--- a/fedot/api/fedot_cli.py
+++ b/fedot/api/fedot_cli.py
@@ -81,7 +81,7 @@ def run_fedot(parameters, main_params, fit_params, save_predictions=True):
 
 # parameters to init Fedot class
 main_params_names = ['problem', 'timeout', 'seed', 'depth', 'arity', 'popsize', 'gen_num',
-                     'opers', 'tuning', 'cv_folds', 'val_bl', 'hist_path', 'preset']
+                     'opers', 'tuning', 'cv_folds', 'hist_path', 'preset']
 # parameters to fit model
 fit_params_names = ['train', 'target']
 

--- a/fedot/api/fedot_cli.py
+++ b/fedot/api/fedot_cli.py
@@ -1,8 +1,9 @@
 import argparse
 from argparse import RawTextHelpFormatter
-from fedot.core.repository.tasks import TsForecastingParams
+from pathlib import Path
+
 from fedot.api.main import Fedot
-import os
+from fedot.core.repository.tasks import TsForecastingParams
 
 
 def create_parser(arguments_list):
@@ -74,7 +75,7 @@ def run_fedot(parameters, main_params, fit_params, save_predictions=True):
     model.fit(**fit_params)
     print("\nPrediction start...")
     prediction = model.predict(features=getattr(parameters, 'test'), in_sample=False, save_predictions=save_predictions)
-    print(f"\nPrediction saved at {os.getcwd()}\\predictions.csv")
+    print(f"\nPrediction saved at {Path.cwd().joinpath('predictions.csv')}")
     return prediction
 
 

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -529,7 +529,7 @@ class Fedot:
         else:
             prediction = predicted_data.predict
         pd.DataFrame({'Index': predicted_data.idx,
-                      'Prediction': prediction}).to_csv(r'./predictions.csv', index=False)
+                      'Prediction': prediction}).to_csv('./predictions.csv', index=False)
         self.log.message('Predictions was saved in current directory.')
 
     def export_as_project(self, project_path='fedot_project.zip'):

--- a/fedot/core/composer/composer_builder.py
+++ b/fedot/core/composer/composer_builder.py
@@ -121,7 +121,7 @@ class ComposerBuilder:
 
     @staticmethod
     def _get_default_complexity_metrics() -> List[MetricsEnum]:
-        return [ComplexityMetricsEnum.node_num]
+        return [ComplexityMetricsEnum.node_number]
 
     def build(self) -> Composer:
         multi_objective = len(self.metrics) > 1

--- a/fedot/core/data/data.py
+++ b/fedot/core/data/data.py
@@ -601,9 +601,9 @@ def np_datetime_to_numeric(data: np.ndarray) -> np.ndarray:
     return features_df.to_numpy(out_dtype).reshape(orig_shape)
 
 
-def array_to_input_data(features_array: np.array,
-                        target_array: np.array,
-                        idx: Optional[np.array] = None,
+def array_to_input_data(features_array: np.ndarray,
+                        target_array: np.ndarray,
+                        idx: Optional[np.ndarray] = None,
                         task: Task = Task(TaskTypesEnum.classification),
                         data_type: Optional[DataTypesEnum] = None) -> InputData:
     if idx is None:

--- a/fedot/core/operations/evaluation/automl.py
+++ b/fedot/core/operations/evaluation/automl.py
@@ -1,16 +1,14 @@
 from typing import Optional
 
 import numpy as np
-
 from h2o import h2o, H2OFrame
 from h2o.automl import H2OAutoML
 from tpot import TPOTClassifier, TPOTRegressor
 
-from fedot.core.operations.operation_parameters import OperationParameters
-from fedot.core.pipelines.automl_wrappers import *
-
 from fedot.core.data.data import InputData, OutputData
 from fedot.core.operations.evaluation.evaluation_interfaces import EvaluationStrategy
+from fedot.core.operations.operation_parameters import OperationParameters
+from fedot.core.pipelines.automl_wrappers import H2OSerializationWrapper, TPOTRegressionSerializationWrapper
 from fedot.core.repository.tasks import TaskTypesEnum
 
 
@@ -110,7 +108,7 @@ class H2OAutoMLClassificationStrategy(EvaluationStrategy):
         train_frame[target_name] = train_frame[target_name].asfactor()
         model = self.operation_impl(max_models=self.params_for_fit.get("max_models"),
                                     seed=self.params_for_fit.get("seed"),
-                                    max_runtime_secs=self.params_for_fit.get("timeout")*60
+                                    max_runtime_secs=self.params_for_fit.get("timeout") * 60
                                     )
 
         model.train(x=train_columns, y=target_name, training_frame=train_frame)
@@ -214,7 +212,6 @@ class TPOTAutoMLClassificationStrategy(EvaluationStrategy):
                                     random_state=42,
                                     max_time_mins=self.params_for_fit.get('timeout', 0.)
                                     )
-        model.classes_ = np.unique(train_data.target)
 
         model.fit(train_data.features.astype(float), train_data.target.astype(int))
 

--- a/fedot/core/operations/evaluation/classification.py
+++ b/fedot/core/operations/evaluation/classification.py
@@ -1,8 +1,6 @@
 import warnings
 from typing import Optional
 
-from golem.core.utilities.random import RandomStateHandler
-
 from fedot.core.data.data import InputData, OutputData
 from fedot.core.operations.evaluation.evaluation_interfaces import EvaluationStrategy, SkLearnEvaluationStrategy
 from fedot.core.operations.evaluation.operation_implementations.data_operations.decompose \
@@ -20,6 +18,7 @@ from fedot.core.operations.evaluation.operation_implementations.models. \
 from fedot.core.operations.evaluation.operation_implementations.models.knn import FedotKnnClassImplementation
 from fedot.core.operations.evaluation.operation_implementations.models.svc import FedotSVCImplementation
 from fedot.core.operations.operation_parameters import OperationParameters
+from fedot.utilities.random import ImplementationRandomStateHandler
 
 warnings.filterwarnings("ignore", category=UserWarning)
 
@@ -66,7 +65,7 @@ class FedotClassificationStrategy(EvaluationStrategy):
 
         operation_implementation = self.operation_impl(self.params_for_fit)
 
-        with RandomStateHandler():
+        with ImplementationRandomStateHandler(implementation=operation_implementation):
             operation_implementation.fit(train_data)
         return operation_implementation
 
@@ -127,7 +126,7 @@ class FedotClassificationPreprocessingStrategy(EvaluationStrategy):
 
         warnings.filterwarnings("ignore", category=RuntimeWarning)
         operation_implementation = self.operation_impl(self.params_for_fit)
-        with RandomStateHandler():
+        with ImplementationRandomStateHandler(implementation=operation_implementation):
             operation_implementation.fit(train_data)
         return operation_implementation
 

--- a/fedot/core/operations/evaluation/clustering.py
+++ b/fedot/core/operations/evaluation/clustering.py
@@ -1,12 +1,12 @@
 import warnings
 from typing import Optional
 
-from golem.core.utilities.random import RandomStateHandler
 from sklearn.cluster import KMeans as SklearnKmeans
 
 from fedot.core.data.data import InputData, OutputData
 from fedot.core.operations.evaluation.evaluation_interfaces import SkLearnEvaluationStrategy
 from fedot.core.operations.operation_parameters import OperationParameters
+from fedot.utilities.random import ImplementationRandomStateHandler
 
 warnings.filterwarnings("ignore", category=UserWarning)
 
@@ -31,7 +31,7 @@ class SkLearnClusteringStrategy(SkLearnEvaluationStrategy):
 
         warnings.filterwarnings("ignore", category=RuntimeWarning)
         operation_implementation = self.operation_impl(**self.params_for_fit.to_dict())
-        with RandomStateHandler():
+        with ImplementationRandomStateHandler(implementation=operation_implementation):
             operation_implementation.fit(train_data.features)
         return operation_implementation
 

--- a/fedot/core/operations/evaluation/common_preprocessing.py
+++ b/fedot/core/operations/evaluation/common_preprocessing.py
@@ -1,8 +1,6 @@
 import warnings
 from typing import Optional
 
-from golem.core.utilities.random import RandomStateHandler
-
 from fedot.core.data.data import InputData, OutputData
 from fedot.core.operations.evaluation.evaluation_interfaces import EvaluationStrategy
 from fedot.core.operations.evaluation.operation_implementations.data_operations.categorical_encoders import \
@@ -11,6 +9,7 @@ from fedot.core.operations.evaluation.operation_implementations.data_operations.
     ImputationImplementation, KernelPCAImplementation, NormalizationImplementation, PCAImplementation, \
     PolyFeaturesImplementation, ScalingImplementation, FastICAImplementation
 from fedot.core.operations.operation_parameters import OperationParameters
+from fedot.utilities.random import ImplementationRandomStateHandler
 
 warnings.filterwarnings("ignore", category=UserWarning)
 
@@ -64,7 +63,7 @@ class FedotPreprocessingStrategy(EvaluationStrategy):
 
         warnings.filterwarnings("ignore", category=RuntimeWarning)
         operation_implementation = self.operation_impl(self.params_for_fit)
-        with RandomStateHandler():
+        with ImplementationRandomStateHandler(implementation=operation_implementation):
             operation_implementation.fit(train_data)
         return operation_implementation
 
@@ -91,7 +90,7 @@ class FedotPreprocessingStrategy(EvaluationStrategy):
             trained_operation: model object
             predict_data: data used for prediction
         Returns:
-            OutputData: 
+            OutputData:
         """
         prediction = trained_operation.transform_for_fit(predict_data)
         converted = self._convert_to_output(prediction, predict_data)

--- a/fedot/core/operations/evaluation/evaluation_interfaces.py
+++ b/fedot/core/operations/evaluation/evaluation_interfaces.py
@@ -5,7 +5,6 @@ from typing import Optional
 import numpy as np
 from catboost import CatBoostClassifier, CatBoostRegressor
 from golem.core.log import default_log
-from golem.core.utilities.random import RandomStateHandler
 from lightgbm.sklearn import LGBMClassifier, LGBMRegressor
 from sklearn.cluster import KMeans as SklearnKmeans
 from sklearn.ensemble import (
@@ -34,6 +33,7 @@ from fedot.core.operations.operation_parameters import OperationParameters
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.operation_types_repository import OperationTypesRepository, get_operation_type_from_id
 from fedot.core.repository.tasks import TaskTypesEnum
+from fedot.utilities.random import ImplementationRandomStateHandler
 
 warnings.filterwarnings("ignore", category=UserWarning)
 
@@ -230,7 +230,7 @@ class SkLearnEvaluationStrategy(EvaluationStrategy):
             operation_implementation = convert_to_multivariate_model(operation_implementation,
                                                                      train_data)
         else:
-            with RandomStateHandler():
+            with ImplementationRandomStateHandler(implementation=operation_implementation):
                 operation_implementation.fit(train_data.features, train_data.target)
         return operation_implementation
 

--- a/fedot/core/operations/evaluation/gpu/clustering.py
+++ b/fedot/core/operations/evaluation/gpu/clustering.py
@@ -1,9 +1,9 @@
 import warnings
 
-from golem.core.utilities.random import RandomStateHandler
 from golem.utilities.requirements_notificator import warn_requirement
 
 from fedot.core.operations.operation_parameters import OperationParameters
+from fedot.utilities.random import ImplementationRandomStateHandler
 
 try:
     from cuml import KMeans
@@ -44,7 +44,7 @@ class CumlClusteringStrategy(CuMLEvaluationStrategy):
             operation_implementation = self.operation_impl(n_clusters=2)
 
         features = cudf.DataFrame(train_data.features.astype('float32'))
-        with RandomStateHandler():
+        with ImplementationRandomStateHandler(implementation=operation_implementation):
             operation_implementation.fit(features)
         return operation_implementation
 

--- a/fedot/core/operations/evaluation/gpu/common.py
+++ b/fedot/core/operations/evaluation/gpu/common.py
@@ -1,8 +1,9 @@
 import warnings
 from typing import Optional
 
-from golem.core.utilities.random import RandomStateHandler
 from golem.utilities.requirements_notificator import warn_requirement
+
+from fedot.utilities.random import ImplementationRandomStateHandler
 
 try:
     import cudf
@@ -83,7 +84,7 @@ class CuMLEvaluationStrategy(SkLearnEvaluationStrategy):
             raise NotImplementedError('Not supported for GPU yet')
             # TODO Manually wrap the regressor into multi-output model
         else:
-            with RandomStateHandler():
+            with ImplementationRandomStateHandler(implementation=operation_implementation):
                 operation_implementation.fit(features, target)
         return operation_implementation
 

--- a/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/cgru.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/cgru.py
@@ -133,8 +133,7 @@ class CGRUImplementation(ModelImplementation):
         :return torch.utils.data.DataLoader: DataLoader with train data
         """
         x, y = self._fit_transform_scaler(input_data)
-        x = torch.from_numpy(x).float()
-        y = torch.from_numpy(y).float()
+        x, y = (torch.from_numpy(np_data.astype(np.float32)) for np_data in (x, y))
         return DataLoader(TensorDataset(x, y), batch_size=self.params.get("batch_size"))
 
     def _fit_transform_scaler(self, data: InputData):

--- a/fedot/core/operations/evaluation/regression.py
+++ b/fedot/core/operations/evaluation/regression.py
@@ -1,8 +1,6 @@
 import warnings
 from typing import Optional
 
-from golem.core.utilities.random import RandomStateHandler
-
 from fedot.core.data.data import InputData, OutputData
 from fedot.core.operations.evaluation.evaluation_interfaces import EvaluationStrategy, SkLearnEvaluationStrategy
 from fedot.core.operations.evaluation.operation_implementations.data_operations.decompose \
@@ -15,6 +13,7 @@ from fedot.core.operations.evaluation.operation_implementations. \
     data_operations.sklearn_selectors import LinearRegFSImplementation, NonLinearRegFSImplementation
 from fedot.core.operations.evaluation.operation_implementations.models.knn import FedotKnnRegImplementation
 from fedot.core.operations.operation_parameters import OperationParameters
+from fedot.utilities.random import ImplementationRandomStateHandler
 
 warnings.filterwarnings("ignore", category=UserWarning)
 
@@ -60,7 +59,7 @@ class FedotRegressionPreprocessingStrategy(EvaluationStrategy):
 
         warnings.filterwarnings("ignore", category=RuntimeWarning)
         operation_implementation = self.operation_impl(self.params_for_fit)
-        with RandomStateHandler():
+        with ImplementationRandomStateHandler(implementation=operation_implementation):
             operation_implementation.fit(train_data)
         return operation_implementation
 
@@ -113,7 +112,7 @@ class FedotRegressionStrategy(EvaluationStrategy):
 
         warnings.filterwarnings("ignore", category=RuntimeWarning)
         operation_implementation = self.operation_impl(self.params_for_fit)
-        with RandomStateHandler():
+        with ImplementationRandomStateHandler(implementation=operation_implementation):
             operation_implementation.fit(train_data)
         return operation_implementation
 

--- a/fedot/core/pipelines/pipeline.py
+++ b/fedot/core/pipelines/pipeline.py
@@ -367,6 +367,11 @@ class Pipeline(GraphDelegate, Serializable):
                     node.node_data = input_data[node.operation.operation_type]
                     node.direct_set = True
                 else:
+                    print(f'Node info: operation={node.operation}, operation_type{node.operation.operation_type},'
+                          f' input_data{input_data}, all_nodes={self.nodes},'
+                          f' pipeline_nodes={[node for node in self.nodes if isinstance(node, PipelineNode)]},',
+                          f' true_node_types={[type(node) for node in self.nodes]},',
+                          f' primary_nodes={[node for node in self.nodes if node.is_primary]}')
                     raise ValueError(f'No data for primary node {node}')
             return None
         return input_data

--- a/fedot/core/repository/default_params_repository.py
+++ b/fedot/core/repository/default_params_repository.py
@@ -1,5 +1,5 @@
-import os
 import json
+import os
 
 
 class DefaultOperationParamsRepository:
@@ -23,6 +23,4 @@ class DefaultOperationParamsRepository:
 
     def get_default_params_for_operation(self, model_name: str) -> dict:
         model_name = model_name.split('/')[0]
-        if model_name in self._repo:
-            return self._repo[model_name]
-        return {}
+        return self._repo.get(model_name, {})

--- a/fedot/core/repository/quality_metrics_repository.py
+++ b/fedot/core/repository/quality_metrics_repository.py
@@ -24,7 +24,7 @@ class QualityMetricsEnum(MetricsEnum):
 
 
 class ComplexityMetricsEnum(MetricsEnum):
-    node_num = 'node_number'
+    node_number = 'node_number'
     structural = 'structural'
     computation_time = 'computation_time_in_seconds'
 
@@ -78,7 +78,7 @@ class MetricsRepository:
 
         # structural
         ComplexityMetricsEnum.structural: StructuralComplexity.get_value,
-        ComplexityMetricsEnum.node_num: NodeNum.get_value,
+        ComplexityMetricsEnum.node_number: NodeNum.get_value,
         ComplexityMetricsEnum.computation_time: ComputationTime.get_value
     }
 

--- a/fedot/utilities/random.py
+++ b/fedot/utilities/random.py
@@ -1,0 +1,33 @@
+import random
+from typing import Optional, Union
+
+import numpy as np
+from golem.core.utilities.random import RandomStateHandler
+
+from fedot.core.operations.evaluation.operation_implementations.implementation_interfaces import \
+    DataOperationImplementation, ModelImplementation
+
+
+class ImplementationRandomStateHandler(RandomStateHandler):
+    MODEL_FITTING_SEED = 0
+
+    def __init__(self, seed: Optional[int] = None,
+                 implementation: Union[DataOperationImplementation, ModelImplementation] = None):
+        super().__init__(seed)
+        self.implementation = implementation
+
+    def __enter__(self):
+        _set_operation_random_seed(self.implementation, self._seed)
+        return super().__enter__()
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        np.random.set_state(self._old_np_state)
+        random.setstate(self._old_state)
+
+
+def _set_operation_random_seed(operation: Union[DataOperationImplementation, ModelImplementation],
+                               seed: Optional[int]):
+    if hasattr(operation, 'random_state'):
+        setattr(operation, 'random_state', seed)
+    elif hasattr(operation, 'seed'):
+        setattr(operation, 'seed', seed)

--- a/fedot/utilities/random.py
+++ b/fedot/utilities/random.py
@@ -1,7 +1,5 @@
-import random
 from typing import Optional, Union
 
-import numpy as np
 from golem.core.utilities.random import RandomStateHandler
 
 from fedot.core.operations.evaluation.operation_implementations.implementation_interfaces import \
@@ -15,19 +13,26 @@ class ImplementationRandomStateHandler(RandomStateHandler):
                  implementation: Union[DataOperationImplementation, ModelImplementation] = None):
         super().__init__(seed)
         self.implementation = implementation
+        self.implementation_old_random_state = None
 
     def __enter__(self):
-        _set_operation_random_seed(self.implementation, self._seed)
+        self.implementation_old_random_state = _set_operation_random_seed(self.implementation, self._seed)
         return super().__enter__()
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
-        np.random.set_state(self._old_np_state)
-        random.setstate(self._old_state)
+        _set_operation_random_seed(self.implementation, self.implementation_old_random_state)
+        return super().__exit__(exc_type, exc_value, exc_traceback)
 
 
 def _set_operation_random_seed(operation: Union[DataOperationImplementation, ModelImplementation],
                                seed: Optional[int]):
+    old_random_state = None
     if hasattr(operation, 'random_state'):
+        old_random_state = getattr(operation, 'random_state')
         setattr(operation, 'random_state', seed)
+
     elif hasattr(operation, 'seed'):
+        old_random_state = getattr(operation, 'seed')
         setattr(operation, 'seed', seed)
+
+    return old_random_state

--- a/other_requirements/examples.txt
+++ b/other_requirements/examples.txt
@@ -1,6 +1,6 @@
 # Other AutoMLs
-tpot == 0.11.7
-h2o == 3.28.1.2
+tpot == 0.12.0
+h2o == 3.42.0.1
 
 # Data
 openpyxl==3.0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Base framework
-thegolem==0.3.2
+thegolem @ git+https://github.com/aimclub/GOLEM.git@stable#egg=thegolem
 
 # Data
 numpy>=1.16.0, !=1.24.0

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+from fedot.core.utils import set_random_seed
+
+
+@pytest.fixture(scope='session', autouse=True)
+def establish_seed():
+    set_random_seed(42)

--- a/test/integration/api/test_api_cli_params.py
+++ b/test/integration/api/test_api_cli_params.py
@@ -23,7 +23,7 @@ def test_cli_with_parameters():
     ts_call = (
         f'--problem ts_forecasting --preset fast_train --timeout 0.1 --depth 3 --arity 3 '
         '--popsize 3 --gen_num 5 --opers lagged linear ridge --tuning 0 '
-        f'--cv_folds 2 --val_bl 2 --target sea_height --train {ts_train_path} '
+        f'--cv_folds 2 --target sea_height --train {ts_train_path} '
         f'--test {ts_train_path} --for_len 10'
     ).split()
     class_train_path = project_root_path.joinpath('test/data/simple_classification.csv')

--- a/test/integration/api/test_api_utils.py
+++ b/test/integration/api/test_api_utils.py
@@ -1,5 +1,4 @@
 import logging
-import random
 from copy import deepcopy
 
 import pytest
@@ -34,10 +33,9 @@ def test_output_binary_classification_correct():
 
     data = get_binary_classification_data()
 
-    random.seed(1)
     train_data, test_data = train_test_data_setup(data, shuffle_flag=True)
 
-    model = Fedot(problem=task_type, timeout=0.1)
+    model = Fedot(problem=task_type, seed=1, timeout=0.1)
     model.fit(train_data, predefined_model='logit')
     model.predict(test_data)
     metrics = model.get_metrics(metric_names=['roc_auc', 'f1'])

--- a/test/integration/api/test_main_api.py
+++ b/test/integration/api/test_main_api.py
@@ -361,7 +361,7 @@ def test_multiobj_for_api():
 
     params = {
         **TESTS_MAIN_API_DEFAULT_PARAMS,
-        'metric': ['f1', 'node_num']
+        'metric': ['f1', 'node_number']
     }
 
     model = Fedot(problem='classification', **params)

--- a/test/integration/api_params/test_main_api_params.py
+++ b/test/integration/api_params/test_main_api_params.py
@@ -46,7 +46,7 @@ def test_timeout(case: TimeoutParams):
     composer_params = {
         'max_depth': 1,
         'max_arity': 1,
-        'pop_size': 1,
+        'pop_size': 2,
         'with_tuning': False,
         'genetic_scheme': GeneticSchemeTypesEnum.generational,
         'num_of_generations': case.test_input['num_of_generations']
@@ -59,7 +59,7 @@ def test_timeout(case: TimeoutParams):
                    'task_params': TsForecastingParams(forecast_length=1),
                    **composer_params}
 
-    train_data, test_data, _ = get_dataset(task_type)
+    train_data, _, _ = get_dataset(task_type)
     if isinstance(case.test_answer, ValueError):
         with pytest.raises(ValueError):
             Fedot(**fedot_input)

--- a/test/integration/automl/test_automl.py
+++ b/test/integration/automl/test_automl.py
@@ -1,34 +1,6 @@
-from datetime import timedelta
-
-import pytest
-
 from examples.advanced.automl.h2o_example import h2o_classification_pipeline_evaluation, \
     h2o_regression_pipeline_evaluation, h2o_ts_pipeline_evaluation
 from fedot.core.repository.operation_types_repository import OperationTypesRepository
-from fedot.core.utils import fedot_project_root
-
-
-@pytest.mark.skip(reason="TPOT dependencies issues")
-def test_pipeline_from_automl_example():
-    from examples.advanced.automl.pipeline_from_automl import run_pipeline_from_automl
-
-    file_path_train = fedot_project_root().joinpath('test/data/simple_classification.csv')
-    file_path_test = file_path_train
-
-    auc = run_pipeline_from_automl(file_path_train, file_path_test, max_run_time=timedelta(seconds=1))
-
-    assert auc > 0.5
-
-
-@pytest.mark.skip(reason="TPOT dependencies issues")
-def test_tpot_vs_fedot_example():
-    from examples.advanced.automl.tpot_vs_fedot import run_tpot_vs_fedot_example
-
-    file_path_train = fedot_project_root().joinpath('test/data/simple_classification.csv')
-    file_path_test = file_path_train
-
-    auc = run_tpot_vs_fedot_example(file_path_train, file_path_test)
-    assert auc > 0.5
 
 
 def test_h2o_vs_fedot_example():

--- a/test/integration/automl/test_automl.py
+++ b/test/integration/automl/test_automl.py
@@ -4,14 +4,14 @@ import pytest
 
 from examples.advanced.automl.h2o_example import h2o_classification_pipeline_evaluation, \
     h2o_regression_pipeline_evaluation, h2o_ts_pipeline_evaluation
-from examples.advanced.automl.pipeline_from_automl import run_pipeline_from_automl
-from examples.advanced.automl.tpot_vs_fedot import run_tpot_vs_fedot_example
 from fedot.core.repository.operation_types_repository import OperationTypesRepository
 from fedot.core.utils import fedot_project_root
 
 
 @pytest.mark.skip(reason="TPOT dependencies issues")
 def test_pipeline_from_automl_example():
+    from examples.advanced.automl.pipeline_from_automl import run_pipeline_from_automl
+
     file_path_train = fedot_project_root().joinpath('test/data/simple_classification.csv')
     file_path_test = file_path_train
 
@@ -22,6 +22,8 @@ def test_pipeline_from_automl_example():
 
 @pytest.mark.skip(reason="TPOT dependencies issues")
 def test_tpot_vs_fedot_example():
+    from examples.advanced.automl.tpot_vs_fedot import run_tpot_vs_fedot_example
+
     file_path_train = fedot_project_root().joinpath('test/data/simple_classification.csv')
     file_path_test = file_path_train
 

--- a/test/integration/automl/test_automl.py
+++ b/test/integration/automl/test_automl.py
@@ -1,5 +1,7 @@
 from datetime import timedelta
 
+import pytest
+
 from examples.advanced.automl.h2o_example import h2o_classification_pipeline_evaluation, \
     h2o_regression_pipeline_evaluation, h2o_ts_pipeline_evaluation
 from examples.advanced.automl.pipeline_from_automl import run_pipeline_from_automl
@@ -8,6 +10,7 @@ from fedot.core.repository.operation_types_repository import OperationTypesRepos
 from fedot.core.utils import fedot_project_root
 
 
+@pytest.mark.skip(reason="TPOT dependencies issues")
 def test_pipeline_from_automl_example():
     file_path_train = fedot_project_root().joinpath('test/data/simple_classification.csv')
     file_path_test = file_path_train
@@ -17,6 +20,7 @@ def test_pipeline_from_automl_example():
     assert auc > 0.5
 
 
+@pytest.mark.skip(reason="TPOT dependencies issues")
 def test_tpot_vs_fedot_example():
     file_path_train = fedot_project_root().joinpath('test/data/simple_classification.csv')
     file_path_test = file_path_train

--- a/test/integration/composer/test_history.py
+++ b/test/integration/composer/test_history.py
@@ -118,7 +118,7 @@ def test_collect_intermediate_metric(pipeline: Pipeline, input_data: InputData, 
     graph_gen_params = get_pipeline_generation_params()
     metrics = [metric]
 
-    data_source = DataSourceSplitter().build(input_data)
+    data_source = DataSourceSplitter(validation_blocks=1).build(input_data)
     objective_eval = PipelineObjectiveEvaluate(MetricsObjective(metrics), data_source)
     dispatcher = MultiprocessingDispatcher(graph_gen_params.adapter)
     dispatcher.set_graph_evaluation_callback(objective_eval.evaluate_intermediate_metrics)

--- a/test/integration/models/test_custom_model_introduction.py
+++ b/test/integration/models/test_custom_model_introduction.py
@@ -224,7 +224,7 @@ def test_composing_with_custom_model():
     initial_assumption = get_simple_pipeline(train_data)
     automl = Fedot(problem='ts_forecasting',
                    timeout=0.1,
-                   task_params=TsForecastingParams(forecast_length=5), logging_level=logging.ERROR,
+                   task_params=TsForecastingParams(forecast_length=5), logging_level=logging.DEBUG,
                    initial_assumption=initial_assumption,
                    preset='ts')
     pipeline = automl.fit(train_data)

--- a/test/integration/models/test_model.py
+++ b/test/integration/models/test_model.py
@@ -109,7 +109,7 @@ def classification_dataset_with_redundant_features(
         n_samples=1000, n_features=100, n_informative=5) -> InputData:
     synthetic_data = make_classification(n_samples=n_samples,
                                          n_features=n_features,
-                                         n_informative=n_informative)
+                                         n_informative=n_informative, random_state=42)
 
     input_data = InputData(idx=np.arange(0, len(synthetic_data[1])),
                            features=synthetic_data[0],

--- a/test/integration/models/test_split_train_test.py
+++ b/test/integration/models/test_split_train_test.py
@@ -13,8 +13,7 @@ from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.tasks import Task, TaskTypesEnum
 
-np.random.seed(1)
-random.seed(1)
+
 N_SAMPLES = 10000
 N_FEATURES = 10
 CORRECT_MODEL_AUC_THR = 0.25

--- a/test/integration/pipelines/tuning/test_pipeline_tuning.py
+++ b/test/integration/pipelines/tuning/test_pipeline_tuning.py
@@ -1,8 +1,6 @@
 import os
-from random import seed
 from time import time
 
-import numpy as np
 import pytest
 from golem.core.tuning.hyperopt_tuner import get_node_parameters_for_hyperopt
 from golem.core.tuning.iopt_tuner import IOptTuner
@@ -24,9 +22,6 @@ from fedot.core.repository.quality_metrics_repository import RegressionMetricsEn
 from fedot.core.repository.tasks import Task, TaskTypesEnum
 from fedot.core.utils import fedot_project_root, NESTED_PARAMS_LABEL
 from test.unit.tasks.test_forecasting import get_ts_data
-
-seed(1)
-np.random.seed(1)
 
 
 @pytest.fixture(scope='package')

--- a/test/integration/quality/test_quality_improvement.py
+++ b/test/integration/quality/test_quality_improvement.py
@@ -1,6 +1,5 @@
 import logging
 import warnings
-
 from typing import Sequence
 
 import numpy as np
@@ -13,27 +12,30 @@ warnings.filterwarnings("ignore")
 
 def test_classification_quality_improvement():
     # input data initialization
-    train_data_path = f'{fedot_project_root()}/cases/data/scoring/scoring_train.csv'
-    test_data_path = f'{fedot_project_root()}/cases/data/scoring/scoring_test.csv'
+    train_data_path = fedot_project_root().joinpath('cases/data/scoring/scoring_train.csv')
+    test_data_path = fedot_project_root().joinpath('cases/data/scoring/scoring_test.csv')
 
-    seed = None
+    seed = 50
     problem = 'classification'
     with_tuning = False
 
-    expected_baseline_quality = 0.823
-    baseline_model = Fedot(problem=problem, seed=seed, with_tuning=with_tuning)
-    baseline_model.fit(features=train_data_path, target='target', predefined_model='rf')
+    common_params = dict(problem=problem,
+                         n_jobs=1,
+                         use_pipelines_cache=False,
+                         use_preprocessing_cache=False,
+                         with_tuning=with_tuning,
+                         logging_level=logging.DEBUG,
+                         seed=seed)
+
+    expected_baseline_quality = 0.750
+    baseline_model = Fedot(**common_params)
+    baseline_model.fit(features=train_data_path, target='target', predefined_model='bernb')
     baseline_model.predict_proba(features=test_data_path)
     baseline_metrics = baseline_model.get_metrics()
 
     # Define parameters for composing
-    timeout = 2
-    composer_params = dict(num_of_generations=20,
-                           with_tuning=with_tuning,
-                           preset='best_quality')
-
-    auto_model = Fedot(problem=problem, timeout=timeout, seed=seed, logging_level=logging.DEBUG,
-                       **composer_params, use_pipelines_cache=False, use_preprocessing_cache=False)
+    auto_model = Fedot(timeout=2, num_of_generations=20, preset='best_quality',
+                       **common_params)
     auto_model.fit(features=train_data_path, target='target')
     auto_model.predict_proba(features=test_data_path)
     auto_metrics = auto_model.get_metrics()
@@ -43,18 +45,19 @@ def test_classification_quality_improvement():
 
 def test_multiobjective_improvement():
     # input data initialization
-    train_data_path = f'{fedot_project_root()}/cases/data/scoring/scoring_train.csv'
-    test_data_path = f'{fedot_project_root()}/cases/data/scoring/scoring_test.csv'
+    train_data_path = fedot_project_root().joinpath('cases/data/scoring/scoring_train.csv')
+    test_data_path = fedot_project_root().joinpath('cases/data/scoring/scoring_test.csv')
     problem = 'classification'
     seed = 50
 
     # Define parameters for composing
-    quality_metric = 'roc_auc'
-    complexity_metric = 'node_num'
-    metrics = [quality_metric, complexity_metric]
+    quality_metric_1 = 'roc_auc'
+    quality_metric_2 = 'accuracy'
+    metrics = [quality_metric_1, quality_metric_2]
 
-    timeout = 2
-    composer_params = dict(num_of_generations=20,
+    timeout = 4
+    composer_params = dict(num_of_generations=10,
+                           pop_size=10,
                            with_tuning=False,
                            preset='best_quality',
                            metric=metrics)
@@ -65,12 +68,12 @@ def test_multiobjective_improvement():
     auto_model.predict_proba(features=test_data_path)
     auto_metrics = auto_model.get_metrics()
 
-    quality_improved, complexity_improved = check_improvement(auto_model.history)
+    quality_1_improved, quality_2_improved = check_improvement(auto_model.history)
 
-    assert auto_metrics['roc_auc'] > 0.75
-    assert auto_metrics['node_num'] >= 2
-    assert quality_improved
-    assert complexity_improved
+    assert auto_metrics[quality_metric_1] > 0.75
+    assert auto_metrics[quality_metric_2] > 0.75
+    assert quality_1_improved
+    assert quality_2_improved
 
 
 def check_improvement(history):
@@ -80,9 +83,9 @@ def check_improvement(history):
     first_pop_metrics = get_mean_metrics(first_pop)
     pareto_front_metrics = get_mean_metrics(pareto_front)
 
-    quality_improved = pareto_front_metrics[0] < first_pop_metrics[0]
-    complexity_improved = pareto_front_metrics[1] < first_pop_metrics[1]
-    return quality_improved, complexity_improved
+    quality_1_improved = pareto_front_metrics[0] < first_pop_metrics[0]
+    quality_2_improved = pareto_front_metrics[1] < first_pop_metrics[1]
+    return quality_1_improved, quality_2_improved
 
 
 def get_mean_metrics(population) -> Sequence[float]:

--- a/test/integration/quality/test_synthetic_tasks.py
+++ b/test/integration/quality/test_synthetic_tasks.py
@@ -1,9 +1,7 @@
 import logging
 import os
-import random
 from functools import partial
 
-import numpy as np
 from sklearn.metrics import mean_squared_error
 
 from fedot.api.main import Fedot
@@ -34,9 +32,6 @@ def get_regression_data():
 
 
 def custom_metric_for_synt_data(pipeline, fit_data, predict_data, **kwargs):
-    np.random.seed(42)
-    random.seed(42)
-
     # reference_data is added for compatibility with composer interface
     pipeline.fit_from_scratch(fit_data)
     results = pipeline.predict(predict_data)
@@ -83,9 +78,8 @@ def test_synthetic_regression_automl():
     test_data.target = ground_truth.predict
 
     # run automl
-    auto_model = Fedot(problem='regression', logging_level=logging.ERROR, timeout=1,
-                       metric=metric_func,
-                       cv_folds=None,
+    auto_model = Fedot(problem='regression', logging_level=logging.DEBUG,
+                       timeout=1, metric=metric_func, cv_folds=None,
                        available_operations=['scaling',
                                              'normalization',
                                              'pca',

--- a/test/integration/real_applications/test_examples.py
+++ b/test/integration/real_applications/test_examples.py
@@ -95,5 +95,5 @@ def test_api_example():
 
 
 def test_multi_modal_example():
-    result = run_multi_modal_example(file_path='examples/data/multimodal_wine.csv', with_tuning=False)
+    result = run_multi_modal_example(file_path='examples/data/multimodal_wine.csv', with_tuning=False, timeout=2)
     assert result > 0.5

--- a/test/integration/real_applications/test_real_cases.py
+++ b/test/integration/real_applications/test_real_cases.py
@@ -1,5 +1,3 @@
-import random
-
 import numpy as np
 from golem.core.tuning.simultaneous import SimultaneousTuner
 from sklearn.metrics import mean_squared_error
@@ -13,14 +11,11 @@ from fedot.core.pipelines.node import PipelineNode
 from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.utils import fedot_project_root
 
-random.seed(1)
-np.random.seed(1)
-
 
 def test_credit_scoring_problem():
     full_path_train = full_path_test = fedot_project_root().joinpath('test/data/simple_classification.csv')
 
-    roc_auc_test = run_credit_scoring_problem(full_path_train, full_path_test, timeout=5, target='Y')
+    roc_auc_test = run_credit_scoring_problem(full_path_train, full_path_test, timeout=5, target='Y', n_jobs=1)
     assert roc_auc_test > 0.5
 
 

--- a/test/integration/remote/test_remote_composer.py
+++ b/test/integration/remote/test_remote_composer.py
@@ -20,11 +20,12 @@ def run_around_tests():
 
 def test_pseudo_remote_composer_classification():
     connect_params = {}
+    common_path = fedot_project_root().joinpath('test', 'data')
     exec_params = {
-        'container_input_path': os.path.join(fedot_project_root(), 'test', 'data'),
-        'container_output_path': os.path.join(fedot_project_root(), 'test', 'data', 'remote'),
-        'container_config_path': os.path.join(fedot_project_root(), 'test', 'data', '.'),
-        'container_image': "test",
+        'container_input_path': common_path,
+        'container_output_path': common_path.joinpath('remote'),
+        'container_config_path': common_path.joinpath('.'),
+        'container_image': 'test',
         'timeout': 1
     }
 
@@ -33,7 +34,7 @@ def test_pseudo_remote_composer_classification():
         dataset_name='advanced_classification')
 
     client = TestClient(connect_params, exec_params,
-                        output_path=os.path.join(fedot_project_root(), 'test', 'data', 'remote'))
+                        output_path=exec_params['container_output_path'])
 
     evaluator = RemoteEvaluator()
 
@@ -52,11 +53,12 @@ def test_pseudo_remote_composer_classification():
 
     automl = Fedot(problem='classification', timeout=0.1, **composer_params)
 
-    path = os.path.join(fedot_project_root(), 'test', 'data', 'advanced_classification.csv')
+    clf_dataset_pth = common_path.joinpath('advanced_classification.csv')
 
-    automl.fit(path)
-    predict = automl.predict(path)
-    shutil.rmtree(os.path.join(fedot_project_root(), 'test', 'data', 'remote', 'fitted_pipeline'))  # recursive deleting
+    automl.fit(clf_dataset_pth)
+    predict = automl.predict(clf_dataset_pth)
+    fitted_pipeline_pth = exec_params['container_output_path'].joinpath('fitted_pipeline')
+    shutil.rmtree(fitted_pipeline_pth, ignore_errors=True)  # recursive deleting
 
     assert predict is not None
 

--- a/test/integration/validation/test_table_cv.py
+++ b/test/integration/validation/test_table_cv.py
@@ -1,0 +1,43 @@
+from datetime import timedelta
+
+from sklearn.metrics import roc_auc_score as roc_auc
+
+from fedot.core.composer.composer_builder import ComposerBuilder
+from fedot.core.data.data_split import train_test_data_setup
+from fedot.core.pipelines.pipeline import Pipeline
+from fedot.core.pipelines.pipeline_composer_requirements import PipelineComposerRequirements
+from fedot.core.repository.operation_types_repository import OperationTypesRepository
+from fedot.core.repository.quality_metrics_repository import ClassificationMetricsEnum
+from fedot.core.repository.tasks import Task, TaskTypesEnum
+from test.unit.validation.test_table_cv import get_classification_data
+
+
+def test_composer_with_cv_optimization_correct():
+    task = Task(task_type=TaskTypesEnum.classification)
+    dataset_to_compose, dataset_to_validate = train_test_data_setup(get_classification_data())
+
+    models_repo = OperationTypesRepository()
+    available_model_types = models_repo.suitable_operation(task_type=task.task_type, tags=['simple'])
+
+    metric_function = [ClassificationMetricsEnum.ROCAUC_penalty,
+                       ClassificationMetricsEnum.accuracy,
+                       ClassificationMetricsEnum.logloss]
+
+    composer_requirements = PipelineComposerRequirements(primary=available_model_types,
+                                                         secondary=available_model_types,
+                                                         timeout=timedelta(minutes=0.2),
+                                                         num_of_generations=2, cv_folds=5,
+                                                         show_progress=False)
+
+    builder = ComposerBuilder(task).with_requirements(composer_requirements).with_metrics(metric_function)
+    composer = builder.build()
+
+    pipeline_evo_composed = composer.compose_pipeline(data=dataset_to_compose)[0]
+
+    assert isinstance(pipeline_evo_composed, Pipeline)
+
+    pipeline_evo_composed.fit(input_data=dataset_to_compose)
+    predicted = pipeline_evo_composed.predict(dataset_to_validate)
+    roc_on_valid_evo_composed = roc_auc(y_score=predicted.predict, y_true=dataset_to_validate.target)
+
+    assert roc_on_valid_evo_composed > 0

--- a/test/unit/common_tests.py
+++ b/test/unit/common_tests.py
@@ -3,9 +3,12 @@ from copy import deepcopy
 import numpy as np
 
 from fedot.core.data.data import InputData, OutputData
+from fedot.core.utils import set_random_seed
 
 
 def is_predict_ignores_target(predict_func, input_data, data_arg_name, predict_args=None):
+    set_random_seed(0)
+
     if predict_args is None:
         predict_args = {}
 
@@ -14,9 +17,7 @@ def is_predict_ignores_target(predict_func, input_data, data_arg_name, predict_a
 
     input_data_without_target = deepcopy(input_data)
     input_data_without_target.target = None
-    np.random.seed(0)
     predictions = predict_func(**{data_arg_name: input_data}, **predict_args)
-    np.random.seed(0)
     predictions_without_target = predict_func(**{data_arg_name: input_data_without_target}, **predict_args)
 
     if isinstance(predictions, OutputData):

--- a/test/unit/composer/test_quality_metrics.py
+++ b/test/unit/composer/test_quality_metrics.py
@@ -22,7 +22,6 @@ from fedot.core.repository.tasks import Task, TaskTypesEnum
 @pytest.fixture()
 def data_setup():
     predictors, response = load_breast_cancer(return_X_y=True)
-    np.random.seed(1)
     np.random.shuffle(predictors)
     np.random.shuffle(response)
     response = response[:100]

--- a/test/unit/data/test_data.py
+++ b/test/unit/data/test_data.py
@@ -18,7 +18,6 @@ from test.unit.tasks.test_forecasting import get_ts_data_with_dt_idx
 @pytest.fixture()
 def data_setup() -> InputData:
     predictors, response = load_iris(return_X_y=True)
-    np.random.seed(1)
     np.random.shuffle(predictors)
     np.random.shuffle(response)
     predictors = predictors[:100]

--- a/test/unit/data/test_data_merge.py
+++ b/test/unit/data/test_data_merge.py
@@ -14,8 +14,6 @@ from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.tasks import Task, TaskTypesEnum
 
-np.random.seed(2021)
-
 
 @pytest.fixture()
 def output_table_1d():

--- a/test/unit/data/test_data_merge_multi_ts.py
+++ b/test/unit/data/test_data_merge_multi_ts.py
@@ -7,8 +7,6 @@ from fedot.core.data.supplementary_data import SupplementaryData
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.tasks import Task, TaskTypesEnum
 
-np.random.seed(2021)
-
 
 @pytest.fixture()
 def equal_outputs_multi_ts():

--- a/test/unit/data/test_data_merge_ts.py
+++ b/test/unit/data/test_data_merge_ts.py
@@ -9,10 +9,7 @@ from fedot.core.pipelines.pipeline_builder import PipelineBuilder
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.tasks import Task, TaskTypesEnum, TsForecastingParams
 from fedot.utilities.synth_dataset_generator import generate_synthetic_data
-
 from test.unit.data_operations.test_data_operations_implementations import get_time_series
-
-np.random.seed(2021)
 
 testing_pipeline_builders = {
     'lagged-ridge':
@@ -85,7 +82,7 @@ def output_ts_different_idx(request):
 
 
 def test_data_merge_ts_pipelines(ts_pipelines):
-    train_input, predict_input, test_data = get_time_series()
+    train_input, predict_input, _ = get_time_series()
 
     pipeline = ts_pipelines.build()
 

--- a/test/unit/data_operations/test_data_definition.py
+++ b/test/unit/data_operations/test_data_definition.py
@@ -1,10 +1,16 @@
 from datetime import datetime
+from typing import Union, Tuple, Optional
 
 import numpy as np
 import pandas as pd
 import pytest
 
+import fedot.api.api_utils.data_definition as fedot_api_api_utils_data_definition
+from fedot.api.api_utils.data_definition import PandasStrategy, TupleStrategy, NumpyStrategy, StrategyDefineData
+from fedot.core.data.data import InputData
 from fedot.core.data.data import np_datetime_to_numeric
+from fedot.core.repository.dataset_types import DataTypesEnum
+from fedot.core.repository.tasks import Task, TaskTypesEnum
 
 _DATE = '2000-01-01T10:00:00.100'
 _DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'
@@ -37,3 +43,55 @@ _DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'
 def test_datetime_erasure(features: np.ndarray):
     result = np_datetime_to_numeric(features)
     assert 'datetime' not in str(pd.DataFrame(result).infer_objects().dtypes)
+
+
+def _array_to_input_data(features_array: np.ndarray,
+                         target_array: np.ndarray,
+                         idx: Optional[np.ndarray] = None,
+                         task: Task = Task(TaskTypesEnum.classification),
+                         data_type: Optional[DataTypesEnum] = None) -> InputData:
+    return np.asarray(features_array), np.asarray(target_array)
+
+
+@pytest.mark.parametrize('strategy, features, task, target, expected', [
+    # None target
+    (NumpyStrategy, np.array([[1]]), Task(TaskTypesEnum.regression), None, (np.array([[1]]), np.array([]))),
+    (PandasStrategy, pd.DataFrame([[1]]), Task(TaskTypesEnum.regression), None,
+     (np.array([[1]]), np.array([]))),
+
+    # Time-series target
+    (NumpyStrategy, np.array([[1]]), Task(TaskTypesEnum.ts_forecasting), None, (np.array([[1]]), np.array([1]))),
+    (NumpyStrategy, np.array([[1]]), Task(TaskTypesEnum.ts_forecasting), np.array([2]),
+     (np.array([[1]]), np.array([[1]]))),
+
+    # Index target
+    (NumpyStrategy, np.array([[1, 2]]), Task(TaskTypesEnum.regression), 1, (np.array([[1]]), np.array([2]))),
+    # Index target, features are already splitted
+    (NumpyStrategy, np.array([[1]]), Task(TaskTypesEnum.regression), 1, (np.array([[1]]), np.array([]))),
+
+    # Str target
+    (PandasStrategy, pd.DataFrame([[1, 2]], columns=['0', '1']), Task(TaskTypesEnum.regression), '1',
+     (np.array([[1]]), np.array([2]))),
+    # Str target, features are already splitted
+    (PandasStrategy, pd.DataFrame([[1]], columns=['0']), Task(TaskTypesEnum.regression), '1',
+     (np.array([[1]]), np.array([]))),
+
+    # Array target
+    (NumpyStrategy, np.array([[1, 2]]), Task(TaskTypesEnum.regression), np.array([0, 1]),
+     (np.array([[1, 2]]), np.array([0, 1]))),
+    (PandasStrategy, pd.DataFrame([[1, 2]]), Task(TaskTypesEnum.regression), pd.Series([0, 1]),
+     (np.array([[1, 2]]), np.array([0, 1]))),
+
+    # Tuple
+    (TupleStrategy, ([1], [2]), Task(TaskTypesEnum.regression), None, ([1], [2]))
+])
+def test_data_strategies(strategy: StrategyDefineData, features: Union[np.ndarray, pd.DataFrame, Tuple],
+                         task: Task, target: Union[None, np.ndarray], expected: Tuple[np.ndarray, np.ndarray],
+                         monkeypatch):
+    monkeypatch.setattr(fedot_api_api_utils_data_definition, 'array_to_input_data', _array_to_input_data)
+
+    obtained_features, obtained_target = strategy().define_data(features=features, task=task, target=target)
+    expected_features, expected_target = expected
+
+    assert np.allclose(obtained_features, expected_features)
+    assert np.allclose(obtained_target, expected_target)

--- a/test/unit/data_operations/test_data_operations_implementations.py
+++ b/test/unit/data_operations/test_data_operations_implementations.py
@@ -25,8 +25,6 @@ from fedot.preprocessing.data_types import NAME_CLASS_FLOAT, NAME_CLASS_INT, \
     NAME_CLASS_STR
 from test.unit.preprocessing.test_preprocessing_through_api import data_with_only_categorical_features
 
-np.random.seed(2021)
-
 
 def get_small_regression_dataset():
     """ Function returns features and target for train and test regression models """

--- a/test/unit/explainability/test_pipeline_explanation.py
+++ b/test/unit/explainability/test_pipeline_explanation.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from typing import Tuple
 
 import numpy as np
 import pytest
@@ -12,11 +13,9 @@ from fedot.core.repository.tasks import Task, TaskTypesEnum
 from fedot.explainability.explainers import explain_pipeline
 from fedot.explainability.surrogate_explainer import SurrogateExplainer, get_simple_pipeline
 
-np.random.seed(1)
-
 
 @pytest.fixture(scope='module')
-def data_for_task_type(request) -> (InputData, Pipeline):
+def data_for_task_type(request) -> Tuple[InputData, Pipeline]:
     task_type = request.param
     if task_type == TaskTypesEnum.classification:
         load_func = load_iris
@@ -27,7 +26,6 @@ def data_for_task_type(request) -> (InputData, Pipeline):
     else:
         raise ValueError(f'Unsupported task type: {task_type}')
     predictors, response = load_func(return_X_y=True)
-    np.random.seed(1)
     np.random.shuffle(predictors)
     np.random.shuffle(response)
     predictors = predictors[:100]

--- a/test/unit/pipelines/test_node.py
+++ b/test/unit/pipelines/test_node.py
@@ -17,7 +17,6 @@ from fedot.core.utils import DEFAULT_PARAMS_STUB, NESTED_PARAMS_LABEL
 @pytest.fixture()
 def data_setup() -> InputData:
     predictors, response = load_iris(return_X_y=True)
-    np.random.seed(1)
     np.random.shuffle(predictors)
     np.random.shuffle(response)
     predictors = predictors[:100]

--- a/test/unit/pipelines/test_node_cache.py
+++ b/test/unit/pipelines/test_node_cache.py
@@ -18,7 +18,6 @@ from fedot.core.repository.tasks import Task, TaskTypesEnum
 def data_setup():
     task = Task(TaskTypesEnum.classification)
     predictors, response = load_breast_cancer(return_X_y=True)
-    np.random.seed(1)
     np.random.shuffle(predictors)
     np.random.shuffle(response)
     response = response[:100]

--- a/test/unit/pipelines/test_pipeline.py
+++ b/test/unit/pipelines/test_pipeline.py
@@ -1,11 +1,9 @@
 import datetime
 import os
 import platform
-import random
 import time
 from copy import deepcopy
 from multiprocessing import set_start_method
-from random import seed
 
 import numpy as np
 import pytest
@@ -24,9 +22,6 @@ from test.integration.models.test_model import classification_dataset_with_redun
 from test.unit.dag.test_graph_operator import get_pipeline
 from test.unit.pipelines.test_pipeline_comparison import pipeline_first
 from test.unit.tasks.test_forecasting import get_ts_data
-
-seed(1)
-np.random.seed(1)
 
 
 @pytest.fixture()
@@ -163,8 +158,6 @@ def test_pipeline_with_datamodel_fit_correct(data_setup):
 
 
 def test_secondary_nodes_is_invariant_to_inputs_order(data_setup):
-    random.seed(1)
-    np.random.seed(1)
     data = data_setup
     # Preprocess data - determine features columns
     data = DataPreprocessor().obligatory_prepare_for_fit(data)

--- a/test/unit/pipelines/test_reproducibility.py
+++ b/test/unit/pipelines/test_reproducibility.py
@@ -1,5 +1,3 @@
-import random
-
 import numpy as np
 
 from fedot.core.data.data_split import train_test_data_setup
@@ -9,11 +7,8 @@ from test.integration.quality.test_synthetic_tasks import get_regression_pipelin
 def test_reproducubility():
     """
     Test validates that two sequential evaluation (fit/predict) of pipelines leads with exactly same result
-    if random seed is fixed
+    if random seed is fixed via session-scoped pytest fixture
     """
-    np.random.seed(1)
-    random.seed(1)
-
     ref_pipeline = get_regression_pipeline()
     input_data = get_regression_data()
 
@@ -21,9 +16,6 @@ def test_reproducubility():
 
     ref_pipeline.fit_from_scratch(train_data)
     pred_1 = ref_pipeline.predict(test_data)
-
-    np.random.seed(1)
-    random.seed(1)
 
     input_data = get_regression_data()
     train_data, test_data = train_test_data_setup(input_data)

--- a/test/unit/tasks/test_forecasting.py
+++ b/test/unit/tasks/test_forecasting.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from random import seed
 from typing import Optional
 
 import numpy as np
@@ -22,9 +21,6 @@ from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.tasks import Task, TaskTypesEnum, TsForecastingParams
 from fedot.core.utils import fedot_project_root
 from fedot.utilities.synth_dataset_generator import generate_synthetic_data
-
-np.random.seed(42)
-seed(42)
 
 
 def _max_rmse_threshold_by_std(values, is_strict=True):

--- a/test/unit/validation/test_table_cv.py
+++ b/test/unit/validation/test_table_cv.py
@@ -4,11 +4,9 @@ from functools import partial
 
 import pytest
 from golem.core.tuning.simultaneous import SimultaneousTuner
-from sklearn.metrics import roc_auc_score as roc_auc
 from sklearn.model_selection import KFold, StratifiedKFold
 
 from fedot.api.main import Fedot
-from fedot.core.composer.composer_builder import ComposerBuilder
 from fedot.core.data.data import InputData
 from fedot.core.data.data_split import train_test_data_setup
 from fedot.core.optimisers.objective import PipelineObjectiveEvaluate
@@ -96,37 +94,6 @@ def test_tuner_cv_classification_correct():
     assert tuned
 
 
-def test_composer_with_cv_optimization_correct():
-    task = Task(task_type=TaskTypesEnum.classification)
-    dataset_to_compose, dataset_to_validate = train_test_data_setup(get_classification_data())
-
-    models_repo = OperationTypesRepository()
-    available_model_types = models_repo.suitable_operation(task_type=task.task_type, tags=['simple'])
-
-    metric_function = [ClassificationMetricsEnum.ROCAUC_penalty,
-                       ClassificationMetricsEnum.accuracy,
-                       ClassificationMetricsEnum.logloss]
-
-    composer_requirements = PipelineComposerRequirements(primary=available_model_types,
-                                                         secondary=available_model_types,
-                                                         timeout=timedelta(minutes=0.2),
-                                                         num_of_generations=2, cv_folds=5,
-                                                         show_progress=False)
-
-    builder = ComposerBuilder(task).with_requirements(composer_requirements).with_metrics(metric_function)
-    composer = builder.build()
-
-    pipeline_evo_composed = composer.compose_pipeline(data=dataset_to_compose)[0]
-
-    assert isinstance(pipeline_evo_composed, Pipeline)
-
-    pipeline_evo_composed.fit(input_data=dataset_to_compose)
-    predicted = pipeline_evo_composed.predict(dataset_to_validate)
-    roc_on_valid_evo_composed = roc_auc(y_score=predicted.predict, y_true=dataset_to_validate.target)
-
-    assert roc_on_valid_evo_composed > 0
-
-
 def test_cv_api_correct():
     composer_params = {'max_depth': 1,
                        'max_arity': 2,
@@ -137,7 +104,7 @@ def test_cv_api_correct():
                        'show_progress': False,
                        'timeout': 0.3}
     dataset_to_compose, dataset_to_validate = train_test_data_setup(get_classification_data())
-    model = Fedot(problem='classification', logging_level=logging.INFO, **composer_params)
+    model = Fedot(problem='classification', logging_level=logging.DEBUG, **composer_params)
     fedot_model = model.fit(features=dataset_to_compose)
     prediction = model.predict(features=dataset_to_validate)
     metric = model.get_metrics(metric_names='f1')


### PR DESCRIPTION
Closes #1110 

Main:
* Unified random seed setting across examples and tests;
* Changed classification enum names (to be precise).

Others:
* moved slow unit test to integration folder;
* extended tests for various data strategies;
* changed logging level in examples.