### PR TITLE
get predict_data.num_classes if trained_model havent num_classes

### DIFF
--- a/fedot/core/operations/evaluation/operation_implementations/models/keras.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/keras.py
@@ -140,10 +140,17 @@ def predict_cnn(trained_model, predict_data: InputData, output_mode: str = 'labe
         prediction = np.round(trained_model.predict(transformed_x_test))
     elif output_mode in ['probs', 'full_probs', 'default']:
         prediction = trained_model.predict(transformed_x_test)
-        if trained_model.num_classes < 2:
+        num_classes = 0
+
+        try:
+            num_classes = trained_model.num_classes
+        except AttributeError:
+            num_classes = predict_data.num_classes
+
+        if num_classes < 2:
             logger.error('Data set contain only 1 target class. Please reformat your data.')
             raise ValueError('Data set contain only 1 target class. Please reformat your data.')
-        elif trained_model.num_classes == 2 and output_mode != 'full_probs' and len(prediction.shape) > 1:
+        elif num_classes == 2 and output_mode != 'full_probs' and len(prediction.shape) > 1:
             prediction = prediction[:, 1]
     else:
         raise ValueError(f'Output model {output_mode} is not supported')


### PR DESCRIPTION
Я заметил, что если обучить CNN модель для классификации изображений, а после сохранить ее и повторно загрузить модель и запустить predict, то выпадает ошибка: AttributeError: 'Sequential' object has no attribute 'num_classes' (у trained_model нет поляnum_classes ) и нужно каждый раз заново обучать модель, а не использовать готовую

Изучив проблему, я понял, что мы можем брать num_classes не только из trained_model, а еще из predict_data. При этом все это нужно обернуть в try catch, чтобы мы взяли num_classes из predict_data только тогда, когда в trained_model нет поля num_classes

Код который использовался для тестирования https://github.com/aimclub/FEDOT/blob/master/examples/simple/classification/image_classification_problem.py

После добавленных изменений модель можно загрузить и сделать predict без каких-либо ошибок

Результаты тестов после добавления изменения остались такими же как и при их запуске после инициализации проекта


