### PR TITLE
1182-fix

### DIFF
--- a/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/naive.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/naive.py
@@ -1,5 +1,4 @@
 from copy import copy
-from typing import Optional
 
 import numpy as np
 

--- a/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/naive.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/naive.py
@@ -104,9 +104,9 @@ class NaiveAverageForecastImplementation(ModelImplementation):
         """ Get desired part of time series for averaging and calculate mean value """
         forecast_length = input_data.task.task_params.forecast_length
 
-        elements_to_take = self._how_many_elements_use_for_averaging(input_data.features)
+        window = self._window(input_data.features)
         # Prepare single forecast
-        mean_value = np.nanmean(input_data.features[-elements_to_take:])
+        mean_value = np.nanmean(input_data.features[-window:])
         forecast = np.array([mean_value] * forecast_length).reshape((1, -1))
 
         output_data = self._convert_to_output(input_data,
@@ -117,9 +117,13 @@ class NaiveAverageForecastImplementation(ModelImplementation):
     def predict_for_fit(self, input_data: InputData) -> OutputData:
         input_data = copy(input_data)
         forecast_length = input_data.task.task_params.forecast_length
-        parts = split_rolling_slices(input_data)
-        mean_values_for_chunks = self.average_by_axis(parts)
-        forecast = np.repeat(mean_values_for_chunks.reshape((-1, 1)), forecast_length, axis=1)
+        features = input_data.features
+        shape = features.shape[0]
+
+        window = self._window(features)
+        mean_values = np.array([np.mean(features[-window-shape+i:i+1]) for i in range(shape)])
+
+        forecast = np.repeat(mean_values.reshape((-1, 1)), forecast_length, axis=1)
 
         # Update target
         new_idx, transformed_target = ts_to_table(idx=input_data.idx, time_series=input_data.target,
@@ -133,42 +137,5 @@ class NaiveAverageForecastImplementation(ModelImplementation):
                                               data_type=DataTypesEnum.table)
         return output_data
 
-    def average_by_axis(self, parts: np.array):
-        """ Perform averaging for each column using last part of it """
-        mean_values_for_chunks = np.apply_along_axis(self._average, 1, parts)
-        return mean_values_for_chunks
-
-    def _average(self, row: np.array):
-        row = row[np.logical_not(np.isnan(row))]
-        if len(row) == 1:
-            return row
-
-        elements_to_take = self._how_many_elements_use_for_averaging(row)
-        return np.mean(row[-elements_to_take:])
-
-    def _how_many_elements_use_for_averaging(self, time_series: np.array):
-        elements_to_take = round(len(time_series) * self.part_for_averaging)
-        elements_to_take = fix_elements_number(elements_to_take)
-        return elements_to_take
-
-
-def split_rolling_slices(input_data: InputData):
-    """ Prepare slices for features series.
-    Example of result for time series [0, 1, 2, 3]:
-    [[0, nan, nan, nan],
-     [0,   1, nan, nan],
-     [0,   1,   2, nan],
-     [0,   1,   2,   3]]
-    """
-    nan_mask = np.triu(np.ones_like(input_data.features, dtype=bool), k=1)
-    final_matrix = np.tril(input_data.features, k=0)
-    final_matrix = np.array(final_matrix, dtype=float)
-    final_matrix[nan_mask] = np.nan
-
-    return final_matrix
-
-
-def fix_elements_number(elements_to_take: int):
-    if elements_to_take < 2:
-        return 2
-    return elements_to_take
+    def _window(self, time_series: np.ndarray):
+        return max(2, round(time_series.shape[0] * self.part_for_averaging))

--- a/fedot/core/repository/data/data_operation_repository.json
+++ b/fedot/core/repository/data/data_operation_repository.json
@@ -219,7 +219,7 @@
 		},
 		"ransac_non_lin_reg": {
 			"meta": "regression_preprocessing",
-			"presets": ["fast_train", "*tree"],
+			"presets": ["*tree"],
 			"tags": ["affects_target", "non_linear", "filtering",
 				     "correct_params", "non_applicable_for_ts", "non-default"]
 		},

--- a/fedot/core/repository/data/data_operation_repository.json
+++ b/fedot/core/repository/data/data_operation_repository.json
@@ -221,7 +221,7 @@
 			"meta": "regression_preprocessing",
 			"presets": ["*tree"],
 			"tags": ["affects_target", "non_linear", "filtering",
-				     "correct_params", "non_applicable_for_ts", "non-default"]
+				     "correct_params", "non_applicable_for_ts"]
 		},
 		"isolation_forest_reg": {
 			"meta": "regression_preprocessing",

--- a/fedot/core/repository/data/data_operation_repository.json
+++ b/fedot/core/repository/data/data_operation_repository.json
@@ -293,7 +293,7 @@
 		},
 		"diff_filter": {
 			"meta": "custom_time_series_transformation",
-			"presets": ["fast_train", "ts"],
+			"presets": ["ts"],
 			"tags": [
 				"differential",
 				"non_lagged",

--- a/test/integration/models/test_model.py
+++ b/test/integration/models/test_model.py
@@ -532,9 +532,9 @@ def test_operations_are_fast():
             reference_time = tuple(map(min, zip(perfomance_values, reference_time)))
 
     for operation in OperationTypesRepository('all')._repo:
-        if (operation.id not in to_skip
-            and operation.presets
-            and FAST_TRAIN_PRESET_NAME in operation.presets):
+        if (operation.id not in to_skip and
+            operation.presets and
+            FAST_TRAIN_PRESET_NAME in operation.presets):
             for _ in range(attempt):
                 perfomance_values = get_operation_perfomance(operation, data_lengths)
                 # if attempt is successful then stop

--- a/test/integration/models/test_model.py
+++ b/test/integration/models/test_model.py
@@ -520,7 +520,8 @@ def test_operations_are_fast():
 
     data_lengths = tuple(map(int, np.logspace(2.2, 4, 6)))
     reference_operations = ['rf', 'rfr']
-    to_skip = ['custom', 'decompose', 'class_decompose', 'kmeans'] + reference_operations
+    to_skip = ['custom', 'decompose', 'class_decompose', 'kmeans',
+               'resample', 'one_hot_encoding'] + reference_operations
     reference_time = (float('inf'), ) * len(data_lengths)
     # tries for time measuring
     attempt = 2

--- a/test/integration/models/test_model.py
+++ b/test/integration/models/test_model.py
@@ -532,9 +532,7 @@ def test_operations_are_fast():
             reference_time = tuple(map(min, zip(perfomance_values, reference_time)))
 
     for operation in OperationTypesRepository('all')._repo:
-        if (operation.id not in to_skip and
-            operation.presets and
-            FAST_TRAIN_PRESET_NAME in operation.presets):
+        if (operation.id not in to_skip and operation.presets and FAST_TRAIN_PRESET_NAME in operation.presets):
             for _ in range(attempt):
                 perfomance_values = get_operation_perfomance(operation, data_lengths)
                 # if attempt is successful then stop

--- a/test/integration/models/test_model.py
+++ b/test/integration/models/test_model.py
@@ -508,7 +508,7 @@ def test_operations_are_fast():
                     if max_time > reference_max_time or second_max_time > reference_second_max_time:
                         fail_operations.append(operation)
 
-    for operation in fail_operations:
+    for operation in fail_operations.copy():
         perfomance_values = get_operation_perfomance(operation, data_lengths)
         max_time = perfomance_values[-1]
         second_max_time = perfomance_values[-2]
@@ -516,7 +516,7 @@ def test_operations_are_fast():
             fail_operations.remove(operation)
 
     assert len(fail_operations) == 0, \
-        f'operations {[op for op in fail_operations]} should not have fast_train preset'
+        f'operations {[operation.id for operation in fail_operations]} should not have fast_train preset'
 
 
 def get_operation_perfomance(operation: OperationMetaInfo,


### PR DESCRIPTION
Test that checks the performance of all operations with synthetic data. Anything slower than Random Forest (`rf` and `rfr`) is considered not fast enough for the `fast_train` preset.

Closes #1182 