### PR TITLE
Change permission to read for pep8 code formatter

### DIFF
--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -12,4 +12,5 @@ jobs:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           reactions: true
           commands: fix-pep8
+          permission: read
           issue-type: pull-request


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

Changing permission to execute `/fix-pep8` command from default write to read.

## Context

In PR #1244 code formatter didn't work. 
Received GitHub [action error](https://github.com/aimclub/FEDOT/actions/runs/7472825751): 
_Request failed due to following response errors: - You do not have permission to view repository collaborators._ 