### PR TITLE
fix sporadic forecasting test failure

### DIFF
--- a/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/statsmodels.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/statsmodels.py
@@ -250,18 +250,24 @@ class ExpSmoothingImplementation(ModelImplementation):
     def __init__(self, params: OperationParameters):
         super().__init__(params)
         self.model = None
-        if self.params.get("seasonal"):
-            self.seasonal_periods = int(self.params.get("seasonal_periods"))
+        if self.params.get('seasonal'):
+            self.seasonal_periods = int(self.params.get('seasonal_periods'))
         else:
             self.seasonal_periods = None
 
     def fit(self, input_data):
+        endog = input_data.features.astype('float64')
+
+        # check ets params according to statsmodels restrictions
+        self._check_and_correct_params(endog)
+        self.log.info(f'Changed the following ETSModel parameters: {self.params.changed_parameters}')
+
         self.model = ETSModel(
-            input_data.features.astype("float64"),
-            error=self.params.get("error"),
-            trend=self.params.get("trend"),
-            seasonal=self.params.get("seasonal"),
-            damped_trend=self.params.get("damped_trend") if self.params.get("trend") else None,
+            endog=endog,
+            error=self.params.get('error'),
+            trend=self.params.get('trend'),
+            seasonal=self.params.get('seasonal'),
+            damped_trend=self.params.get('damped_trend') if self.params.get('trend') else None,
             seasonal_periods=self.seasonal_periods
         )
         self.model = self.model.fit(disp=False)
@@ -312,3 +318,16 @@ class ExpSmoothingImplementation(ModelImplementation):
                                               predict=predict,
                                               data_type=DataTypesEnum.table)
         return output_data
+
+    def _check_and_correct_params(self, endog: np.ndarray) -> None:
+        ets_components = ['error', 'trend', 'seasonal']
+        if any(self.params.get(component) == 'mul' for component in ets_components):
+            if np.any(endog <= 0):
+                for component in ets_components:
+                    if self.params.get(component) == 'mul':
+                        self.params.update(**{f'{component}': 'add'})
+
+        if self.params.get('trend') == 'mul' \
+                and self.params.get('damped_trend') \
+                and not self.params.get('seasonal'):
+            self.params.update(trend='add')

--- a/fedot/core/pipelines/tuning/search_space.py
+++ b/fedot/core/pipelines/tuning/search_space.py
@@ -323,7 +323,7 @@ class PipelineSearchSpace(SearchSpace):
                     'type': 'categorical'},
                 'seasonal_periods': {
                     'hyperopt-dist': hp.uniform,
-                    'sampling-scope': [1, 100],
+                    'sampling-scope': [2, 100],
                     'type': 'continuous'}
             },
             'glm': {

--- a/other_requirements/extra.txt
+++ b/other_requirements/extra.txt
@@ -7,7 +7,7 @@ opencv-python >= 4.5.5.64
 Pillow >= 8.2.0
 
 # Texts
-gensim >= 4.1.2
+gensim @ git+https://github.com/piskvorky/gensim.git@ad68ee3
 nltk >= 3.5
 
 # Misc


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

- [x] Changed search space for the field of a [seasonal_periods](https://github.com/statsmodels/statsmodels/blob/55ee0516b4bf48a112b8bdabebfb49df815adc90/statsmodels/tsa/exponential_smoothing/ets.py#L447-L466) 488c12f
- [x] Added extra validation for the `ETSModel` parameters to avoid NaNs in the fitted data 47371c0
- [x] Resolved gensim dependency to [recent gensim fix-commit](https://github.com/piskvorky/gensim/commit/ad68ee3f105fc37cf8db333bfb837fe889ff74ac) 94df381

## Context

closes #1279 