### PR TITLE
add validation on _window_size param in topo extractor

### DIFF
--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/topological/fast_topological_extractor.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/topological/fast_topological_extractor.py
@@ -35,6 +35,7 @@ class TopologicalFeaturesImplementation(DataOperationImplementation):
         self._window_size = int(input_data.features.shape[1] * self.window_size_as_share)
         self._window_size = max(self._window_size, 2)
         self._window_size = min(self._window_size, input_data.features.shape[1] - 2)
+        self._window_size = max(self._window_size, 1)
         return self
 
     def transform(self, input_data: InputData) -> OutputData:

--- a/test/unit/data_operations/test_data_operation_params.py
+++ b/test/unit/data_operations/test_data_operation_params.py
@@ -2,6 +2,7 @@ from copy import copy
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from fedot.core.data.data import InputData
 from fedot.core.data.data_split import train_test_data_setup
@@ -10,6 +11,7 @@ from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.tasks import Task, TaskTypesEnum, TsForecastingParams
 from fedot.core.utils import fedot_project_root
+from .test_time_series_operations import get_timeseries
 
 
 def get_ts_pipeline(window_size):
@@ -102,3 +104,15 @@ def test_params_filter_with_non_default():
     assert default_params == {}
     assert 'n_neighbors' in list(updated_params.keys())
     assert len(list(updated_params.keys())) == 1
+
+
+@pytest.mark.parametrize(('length', 'features_count', 'target_count', 'window_size'),
+                         [(40, 1, 1, 10), (5, 1, 1, 10), (4, 1, 1, 10), (2, 1, 1, 10), (1, 1, 1, 10)])
+def test_positive_window_size_in_fast_topo(length, features_count, target_count, window_size):
+    data = get_timeseries(length=length, features_count=features_count, target_count=target_count, random=True)
+    lagged_node = PipelineNode('lagged')
+    lagged_node.parameters = {'window_size': window_size}
+    lagged_data = lagged_node.fit(data)
+    topo_node = PipelineNode('topological_features')
+    topo_node.fit(lagged_data)
+    assert topo_node.fitted_operation._window_size > 0


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

- [x] add mandatory non-negative and non-zero validation on window size param inside a `TopologicalFeaturesImplementation` fit (1c04aad)
- [x]  add unit test for a non-negative window check and extraction method validation (77a9c78)

## Context
fixed [integration test](https://github.com/aimclub/FEDOT/blob/0bdece11af60d6e9abc84a894ddd66ea960b5611/test/integration/real_applications/test_examples.py#L86-L88) failure with: `ValueError: Found array with 0 feature(s) (shape=(3, 0)) while a minimum of 1 is required by check_pairwise_arrays.`