### PR TITLE
Fix gensim for PyPi release

### DIFF
--- a/other_requirements/extra.txt
+++ b/other_requirements/extra.txt
@@ -7,7 +7,7 @@ opencv-python >= 4.5.5.64
 Pillow >= 8.2.0
 
 # Texts
-gensim @ git+https://github.com/piskvorky/gensim.git@ad68ee3
+gensim==4.3.2
 nltk >= 3.5
 
 # Misc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+scipy==1.11.0
 # Base framework
 thegolem==0.4.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-scipy==1.11.1
+scipy==1.10.1; python_version <= '3.8'
+scipy==1.11.1; python_version > '3.8'
+
 # Base framework
 thegolem==0.4.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-scipy==1.10.1; python_version <= '3.8'
-scipy==1.11.1; python_version > '3.8'
+scipy<1.13.0
 
 # Base framework
 thegolem==0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scipy==1.11.0
+scipy==1.11.1
 # Base framework
 thegolem==0.4.0
 


### PR DESCRIPTION
This is a 🐛 bug fix

## Summary

Fix gensim problem with pinned dependencies versions

## Context

PyPi intermediate release 0.7.3.2 doesn't publish:
```
Can't have direct dependency: gensim@                                  
git+https://github.com/piskvorky/gensim.git@ad68ee3 ; extra == "extra".
```
https://github.com/aimclub/FEDOT/actions/runs/8849483743/job/24301597093
