### PR TITLE
Update version of codecov action

### DIFF
--- a/.github/workflows/unit-build.yml
+++ b/.github/workflows/unit-build.yml
@@ -36,4 +36,4 @@ jobs:
       run: |
         pytest --cov=fedot -s test/unit
     - name: Codecov-coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4


### PR DESCRIPTION
This is a 🐛 bug fix.
## Summary

Update codecov github action version from 1 to 4 (latest)

## Context

Tests failures in https://github.com/aimclub/FEDOT/pull/1287 and https://github.com/aimclub/FEDOT/pull/1288 due to codecov error
