### PR TITLE
fix: NaNs containing forecast on some ets configs

### DIFF
--- a/fedot/core/repository/data/model_repository.json
+++ b/fedot/core/repository/data/model_repository.json
@@ -417,6 +417,7 @@
         "simple",
         "interpretable",
         "non_lagged",
+        "correct_params",
         "non_linear"
       ],
 	  "input_type": "[DataTypesEnum.ts]"


### PR DESCRIPTION
This is a 🐛 bug fix.

- [x] add default ETSModel fall-back on a convergence warning
- [x] run local tests on troubled pipelines
- [x] run integration workflow  


closes #1285 
