### PR TITLE
Update unit-build.yml

### DIFF
--- a/.github/workflows/unit-build.yml
+++ b/.github/workflows/unit-build.yml
@@ -37,3 +37,5 @@ jobs:
         pytest --cov=fedot -s test/unit
     - name: Codecov-coverage
       uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Your unit-test coverage report stops uploading about 2 month ago (just like with Fedot.Industrial). It is almost invisible issue, because it doesn't invoke any exception during execution. 

But it could be found in action logs if you unfold `Codecove-coverage`, for example [here](https://github.com/aimclub/FEDOT/actions/runs/9128896764/job/25102188426?pr=1292):

```console
Error: Codecov token not found. Please provide Codecov token with -t flag.
Warning: Codecov: Failed to properly create commit: The process '/home/runner/work/_actions/codecov/codecov-action/v4/dist/codecov' failed with exit code 1
```

It is now fixed in Fedot.Industrial via proposed instruction in action script

Just update `CODECOVE_TOKEN` secret from [codecov-app](https://app.codecov.io/gh/aimclub/FEDOT/settings)

ps: [proof](https://github.com/codecov/codecov-action) that it is need to be done
