### PR TITLE
fix: NaNs containing data on fit stage for fast_ica

### DIFF
--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_transformations.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_transformations.py
@@ -47,6 +47,9 @@ class ComponentAnalysisImplementation(DataOperationImplementation):
 
         if self.number_of_features > 1:
             self.check_and_correct_params(is_ts_data=input_data.data_type is DataTypesEnum.ts)
+            # TODO: remove a workaround by refactoring other operations in troubled pipelines (e.g. topo)
+            # workaround for NaN-containing arrays during pca fitting, especially for fast_ica
+            # fast_ica cannot fit with features represented by a rather sparse matrix
             try:
                 self.pca.fit(input_data.features)
             except Exception as e:

--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_transformations.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_transformations.py
@@ -47,7 +47,12 @@ class ComponentAnalysisImplementation(DataOperationImplementation):
 
         if self.number_of_features > 1:
             self.check_and_correct_params(is_ts_data=input_data.data_type is DataTypesEnum.ts)
-            self.pca.fit(input_data.features)
+            try:
+                self.pca.fit(input_data.features)
+            except Exception as e:
+                self.log.info(f'Switched from {type(self.pca).__name__} to default PCA on fit stage due to {e}')
+                self.pca = PCA()
+                self.pca.fit(input_data.features)
 
         return self.pca
 

--- a/fedot/core/operations/evaluation/operation_implementations/implementation_interfaces.py
+++ b/fedot/core/operations/evaluation/operation_implementations/implementation_interfaces.py
@@ -19,6 +19,7 @@ class DataOperationImplementation(ABC):
 
     def __init__(self, params: Optional[OperationParameters] = None):
         self.params = params or OperationParameters()
+        self.log = default_log(self)
 
     @abstractmethod
     def fit(self, input_data: InputData):


### PR DESCRIPTION
This is a 🐛 bug fix.

This PR aims to fix the `ValueError: array must not contain infs or NaNs` for pipelines with `fast_ica` node.


- [x] Add default PCA fallback on FastICA error (640a43c)
- [x] Perform local integration testing to ensure a thorough check
- [x] Perform integration testing on Github Actions

Context and reproducibility steps:
closes #1293 