### PR TITLE
fix: go for forecast method instead of predict in ets

### DIFF
--- a/fedot/api/api_utils/assumptions/assumptions_handler.py
+++ b/fedot/api/api_utils/assumptions/assumptions_handler.py
@@ -78,9 +78,7 @@ class AssumptionsHandler:
             pipeline.predict(data_test)
             self.log.info('Initial pipeline was fitted successfully')
 
-            MemoryAnalytics.log(self.log,
-                                additional_info='fitting of the initial pipeline',
-                                logging_level=45)  # message logging level
+            MemoryAnalytics.log(self.log, additional_info='fitting of the initial pipeline')
 
         except Exception as ex:
             self._raise_evaluating_exception(ex)

--- a/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/statsmodels.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/statsmodels.py
@@ -288,17 +288,14 @@ class ExpSmoothingImplementation(ModelImplementation):
 
     def predict(self, input_data):
         input_data = copy(input_data)
-        idx = input_data.idx
+        forecast_length = input_data.task.task_params.forecast_length
 
-        start_id = idx[0]
-        end_id = idx[-1]
-        predictions = self.model.predict(start=start_id,
-                                         end=end_id)
-        predict = predictions
-        predict = np.array(predict).reshape(1, -1)
-        new_idx = np.arange(start_id, end_id + 1)
+        start_id = input_data.idx[0]
+        end_id = start_id + forecast_length - 1
+        predictions = self.model.forecast(steps=forecast_length)
+        predict = np.array(predictions).reshape(1, -1)
 
-        input_data.idx = new_idx
+        input_data.idx = np.arange(start_id, end_id)
 
         output_data = self._convert_to_output(input_data,
                                               predict=predict,

--- a/fedot/utilities/memory.py
+++ b/fedot/utilities/memory.py
@@ -22,8 +22,7 @@ class MemoryAnalytics:
         """
         Finish memory monitoring session
         """
-        cls.log(additional_info='finish',
-                logging_level=45)  # message logging level
+        cls.log(additional_info='finish')
         tracemalloc.stop()
         cls.is_active = False
 


### PR DESCRIPTION
This is a 🐛 bug fix.
Related to `api_ts_forecasting_example` integration test failure.

- [x] Change predict logic by calling forecasting method instead of a predict one in `ExpSmoothingImplementation` (27315b2)
- [x] Make sure that this resolves the issue with that kind of pipelines by running saved troubled pipelines locally
- [x] Remove obsolete custom message logging level (da4fc93)

related to #1297, but not closing it since there are various types of troubled pipelines
closes #1300 