### PR TITLE
fix: indexing and seasonal_periods check that endog is at least twice the size

### DIFF
--- a/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/statsmodels.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/statsmodels.py
@@ -345,4 +345,10 @@ class ExpSmoothingImplementation(ModelImplementation):
             self.params.update(**{'trend': 'add'})
             params_changed = True
 
+        if self.params.get('seasonal'):
+            self.seasonal_periods = min(int(0.5 * (len(endog) - 1)), self.seasonal_periods)
+            self.seasonal_periods = max(self.seasonal_periods, 1)
+            self.params.update(**{'seasonal_periods': self.seasonal_periods})
+            params_changed = True
+
         return params_changed

--- a/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/statsmodels.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/ts_implementations/statsmodels.py
@@ -295,7 +295,7 @@ class ExpSmoothingImplementation(ModelImplementation):
         predictions = self.model.forecast(steps=forecast_length)
         predict = np.array(predictions).reshape(1, -1)
 
-        input_data.idx = np.arange(start_id, end_id)
+        input_data.idx = np.arange(start_id, end_id + 1)
 
         output_data = self._convert_to_output(input_data,
                                               predict=predict,


### PR DESCRIPTION
This is a :fire: hotfix.

## Summary
- [x] Add seasonal_periods check that endog is at least twice the size (a79d3d3)
- [x] Set proper index array size (c53af7a)

## Context
related to https://github.com/aimclub/FEDOT/actions/runs/9499709347 integration workflow failure
related to #1297
