### PR TITLE
fix: bring back cgru integration tests

### DIFF
--- a/docs/source/introduction/fedot_features/automation_features.rst
+++ b/docs/source/introduction/fedot_features/automation_features.rst
@@ -147,7 +147,7 @@ Apart from that there are other options whose names speak for themselves: ``'sta
    `sgdr`,Stochastic Gradient Descent regressor,Regression
    `svr`,Linear Support Vector regressor,Regression
    `treg`,Extra Trees regressor,Regression
-   `xgbreg`,Extreme Gradient Boosting regressor,Regression
+   `xgboostreg`,Extreme Gradient Boosting regressor,Regression
    `bernb`,Naive Bayes classifier (multivariate Bernoulli),Classification
    `catboost`,Catboost classifier,Classification
    `cnn`,Convolutional Neural Network,Classification
@@ -190,7 +190,7 @@ Apart from that there are other options whose names speak for themselves: ``'sta
    `sgdr`,`sklearn.linear_model.SGDRegressor`,`fast_train` `ts`
    `svr`,`sklearn.svm.LinearSVR`,
    `treg`,`sklearn.ensemble.ExtraTreesRegressor`,`*tree`
-   `xgbreg`,`xgboost.XGBRegressor`,`*tree`
+   `xgboostreg`,`FEDOT model`,`*tree`
    `bernb`,`sklearn.naive_bayes.BernoulliNB`,`fast_train`
    `catboost`,`catboost.CatBoostClassifier`,`*tree`
    `cnn`,`FEDOT model`,
@@ -204,7 +204,7 @@ Apart from that there are other options whose names speak for themselves: ``'sta
    `qda`,`sklearn.discriminant_analysis.QuadraticDiscriminantAnalysis`,`fast_train`
    `rf`,`sklearn.ensemble.RandomForestClassifier`,`fast_train` `*tree`
    `svc`,`sklearn.svm.SVC`,
-   `xgboost`,`xgboost.XGBClassifier`,`*tree`
+   `xgboost`,`FEDOT model`,`*tree`
    `kmeans`,`sklearn.cluster.Kmeans`,`fast_train`
    `ar`,`statsmodels.tsa.ar_model.AutoReg`,`fast_train` `ts`
    `arima`,`statsmodels.tsa.arima.model.ARIMA`,`ts`

--- a/docs/source/introduction/fedot_features/automation_features.rst
+++ b/docs/source/introduction/fedot_features/automation_features.rst
@@ -190,7 +190,7 @@ Apart from that there are other options whose names speak for themselves: ``'sta
    `sgdr`,`sklearn.linear_model.SGDRegressor`,`fast_train` `ts`
    `svr`,`sklearn.svm.LinearSVR`,
    `treg`,`sklearn.ensemble.ExtraTreesRegressor`,`*tree`
-   `xgboostreg`,`FEDOT model`,`*tree`
+   `xgboostreg`,`xgboost.XGBRegressor`,`*tree`
    `bernb`,`sklearn.naive_bayes.BernoulliNB`,`fast_train`
    `catboost`,`catboost.CatBoostClassifier`,`*tree`
    `cnn`,`FEDOT model`,
@@ -204,7 +204,7 @@ Apart from that there are other options whose names speak for themselves: ``'sta
    `qda`,`sklearn.discriminant_analysis.QuadraticDiscriminantAnalysis`,`fast_train`
    `rf`,`sklearn.ensemble.RandomForestClassifier`,`fast_train` `*tree`
    `svc`,`sklearn.svm.SVC`,
-   `xgboost`,`FEDOT model`,`*tree`
+   `xgboost`,`xgboost.XGBClassifier`,`*tree`
    `kmeans`,`sklearn.cluster.Kmeans`,`fast_train`
    `ar`,`statsmodels.tsa.ar_model.AutoReg`,`fast_train` `ts`
    `arima`,`statsmodels.tsa.arima.model.ARIMA`,`ts`

--- a/test/integration/api/test_main_api.py
+++ b/test/integration/api/test_main_api.py
@@ -166,8 +166,6 @@ def test_pandas_input_for_api():
 
     train_features = pd.DataFrame(train_data.features)
     train_target = pd.Series(train_data.target.reshape(-1))
-
-    test_features = pd.DataFrame(test_data.features)
     test_target = pd.Series(test_data.target.reshape(-1))
 
     # task selection, initialisation of the framework
@@ -177,7 +175,7 @@ def test_pandas_input_for_api():
     baseline_model.fit(features=train_features, target=train_target, predefined_model='xgboost')
 
     # evaluate the prediction with test data
-    prediction = baseline_model.predict(features=test_features)
+    prediction = baseline_model.predict(features=test_data)
 
     assert len(prediction) == len(test_target)
 

--- a/test/integration/models/test_model.py
+++ b/test/integration/models/test_model.py
@@ -497,18 +497,15 @@ def test_operations_are_serializable(operation):
                                         length=100, features_count=2,
                                         random=True)
             if data is not None:
-                try:
-                    nodes_from = []
-                    if task_type is TaskTypesEnum.ts_forecasting:
-                        if 'non_lagged' not in operation.tags:
-                            nodes_from = [PipelineNode('lagged')]
-                    node = PipelineNode(operation.id, nodes_from=nodes_from)
-                    pipeline = Pipeline(node)
-                    pipeline.fit(data)
-                    serialized = pickle.dumps(pipeline, pickle.HIGHEST_PROTOCOL)
-                    assert isinstance(serialized, bytes)
-                except NotImplementedError:
-                    pass
+                nodes_from = []
+                if task_type is TaskTypesEnum.ts_forecasting:
+                    if 'non_lagged' not in operation.tags:
+                        nodes_from = [PipelineNode('lagged')]
+                node = PipelineNode(operation.id, nodes_from=nodes_from)
+                pipeline = Pipeline(node)
+                pipeline.fit(data)
+                serialized = pickle.dumps(pipeline, pickle.HIGHEST_PROTOCOL)
+                assert isinstance(serialized, bytes)
 
 
 def test_operations_are_fast():

--- a/test/integration/models/test_model.py
+++ b/test/integration/models/test_model.py
@@ -465,8 +465,7 @@ def test_locf_forecast_correctly():
 def test_models_does_not_fall_on_constant_data(operation):
     """ Run models on constant data """
     # models that raise exception
-    to_skip = ['custom', 'arima', 'catboost', 'catboostreg', 'cgru',
-               'lda', 'fast_ica', 'decompose', 'class_decompose']
+    to_skip = {'custom', 'arima', 'catboost', 'catboostreg', 'cgru', 'lda', 'decompose', 'class_decompose'}
     if operation.id in to_skip:
         return
 

--- a/test/integration/real_applications/test_heavy_models.py
+++ b/test/integration/real_applications/test_heavy_models.py
@@ -5,26 +5,15 @@ from examples.simple.time_series_forecasting.ts_pipelines import cgru_pipeline
 from fedot.core.pipelines.pipeline_builder import PipelineBuilder
 
 
-@pytest.mark.skip(reason="Fails due to the https://github.com/aimclub/FEDOT/issues/1240")
-def test_cgru_forecasting():
+@pytest.mark.parametrize('pipeline', (
+    PipelineBuilder().add_node('lagged', params={'window_size': 200}).add_node('cgru').build(),
+    cgru_pipeline(),
+), ids=str)
+def test_cgru_forecasting(pipeline):
     horizon = 5
-    window_size = 200
-    train_data, test_data = get_ts_data('salaries', horizon)
-
-    pipeline = PipelineBuilder().add_node('lagged', params={'window_size': window_size}).add_node('cgru').build()
+    train_data, test_data, _ = get_ts_data('salaries', horizon)
     pipeline.fit(train_data)
-    predicted = pipeline.predict(test_data).predict[0]
+    predicted = pipeline.predict(test_data).predict
 
-    assert len(predicted) == horizon
-
-
-@pytest.mark.skip(reason="Fails due to the https://github.com/aimclub/FEDOT/issues/1240")
-def test_cgru_in_pipeline():
-    horizon = 5
-    train_data, test_data = train_data, test_data = get_ts_data('salaries', horizon)
-
-    pipeline = cgru_pipeline()
-    pipeline.fit(train_data)
-    predicted = pipeline.predict(test_data).predict[0]
-
+    assert predicted is not None
     assert len(predicted) == horizon


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

- [x] parametrize tests by models (04d9a15)
- [x] restore the integration tests for the CGRU (a7c4022)
- [x] fix integration tests failure (5dc247c, 4b6fd17)
- [ ] ~restore the integration test scenarios with CGRU model (WIP)~

## Context

fixes #1240
fixes recent [integration tests failure](https://github.com/aimclub/FEDOT/actions/runs/10123551790/job/27996942320)