### PR TITLE
hotfix: add punkt_tab to nltk LookupError check

### DIFF
--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/text_preprocessing.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/text_preprocessing.py
@@ -65,7 +65,7 @@ class TextCleanImplementation(DataOperationImplementation):
 
     @staticmethod
     def _download_nltk_resources():
-        for resource in ['punkt']:
+        for resource in ['punkt', 'punkt_tab']:
             try:
                 nltk.data.find(f'tokenizers/{resource}')
             except LookupError:


### PR DESCRIPTION
This is a 🐛 bug fix. 

## Summary

- [x] Added the `punkt_tab` to the list of required NLTK resources.

## Context
fixes recent integration tests failures:
https://github.com/aimclub/FEDOT/actions/runs/10339781677
