### PR TITLE
hotfix: pin nltk version to avoid downloading punkt_tab

### DIFF
--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/text_preprocessing.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/text_preprocessing.py
@@ -65,7 +65,7 @@ class TextCleanImplementation(DataOperationImplementation):
 
     @staticmethod
     def _download_nltk_resources():
-        for resource in ['punkt', 'punkt_tab']:
+        for resource in ['punkt']:
             try:
                 nltk.data.find(f'tokenizers/{resource}')
             except LookupError:

--- a/other_requirements/extra.txt
+++ b/other_requirements/extra.txt
@@ -8,7 +8,7 @@ Pillow >= 8.2.0
 
 # Texts
 gensim==4.3.2
-nltk >= 3.5
+nltk==3.8.1
 
 # Misc
 protobuf~=3.19.0


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary
 
- [x] remove `punkt_tab` from lookup list when downloading nltk resources (20a6d88)
- [x] pin nltk version to stable 3.8.1 (c75c43)

## Context

related to https://github.com/nltk/nltk/issues/3293
