### PR TITLE
fix: do not launch composition for atomized model

### DIFF
--- a/fedot/api/api_utils/predefined_model.py
+++ b/fedot/api/api_utils/predefined_model.py
@@ -31,7 +31,9 @@ class PredefinedModel:
         else:
             raise ValueError(f'{type(self.predefined_model)} is not supported as Fedot model')
 
-        verify_pipeline(pipelines, task_type=self.data.task.task_type, raise_on_failure=True)
+        # ISSUE #1317 Quick Fix: Skip pipeline verification for Atomized Model
+        if not "atomized" in pipelines.descriptive_id:
+            verify_pipeline(pipelines, task_type=self.data.task.task_type, raise_on_failure=True)
 
         return pipelines
 

--- a/fedot/api/api_utils/predefined_model.py
+++ b/fedot/api/api_utils/predefined_model.py
@@ -31,7 +31,10 @@ class PredefinedModel:
         else:
             raise ValueError(f'{type(self.predefined_model)} is not supported as Fedot model')
 
-        if "atomized" not in pipelines.descriptive_id:
+        # TODO: Workaround for AtomizedModel
+        if "atomized" in pipelines.descriptive_id:
+            self.log.message("Pipeline verification for AtomizedModel currently unavailable")
+        else:
             verify_pipeline(pipelines, task_type=self.data.task.task_type, raise_on_failure=True)
 
         return pipelines

--- a/fedot/api/api_utils/predefined_model.py
+++ b/fedot/api/api_utils/predefined_model.py
@@ -32,7 +32,7 @@ class PredefinedModel:
             raise ValueError(f'{type(self.predefined_model)} is not supported as Fedot model')
 
         # ISSUE #1317 Quick Fix: Skip pipeline verification for Atomized Model
-        if not "atomized" in pipelines.descriptive_id:
+        if "atomized" not in pipelines.descriptive_id:
             verify_pipeline(pipelines, task_type=self.data.task.task_type, raise_on_failure=True)
 
         return pipelines

--- a/fedot/api/api_utils/predefined_model.py
+++ b/fedot/api/api_utils/predefined_model.py
@@ -31,8 +31,7 @@ class PredefinedModel:
         else:
             raise ValueError(f'{type(self.predefined_model)} is not supported as Fedot model')
 
-        # ISSUE #1317 Quick Fix: Skip pipeline verification for Atomized Model
-        if "atomized" not in pipelines.descriptive_id:
+        if not "atomized" in pipelines.descriptive_id:
             verify_pipeline(pipelines, task_type=self.data.task.task_type, raise_on_failure=True)
 
         return pipelines

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -167,8 +167,9 @@ class Fedot:
                 self.train_data = self.data_processor.fit_transform(self.train_data)
 
         init_asm = self.params.data.get('initial_assumption')
-        if (predefined_model is None) and init_asm and ("atomized" in init_asm.descriptive_id):
-            predefined_model = init_asm
+        if (predefined_model is None):
+            if isinstance(init_asm, Pipeline) and ("atomized" in init_asm.descriptive_id):
+                predefined_model = init_asm
 
         with fedot_composer_timer.launch_fitting():
             if predefined_model is not None:

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -167,7 +167,7 @@ class Fedot:
                 self.train_data = self.data_processor.fit_transform(self.train_data)
 
         init_asm = self.params.data.get('initial_assumption')
-        if (predefined_model is None):
+        if predefined_model is None:
             if isinstance(init_asm, Pipeline) and ("atomized" in init_asm.descriptive_id):
                 predefined_model = init_asm
 

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -166,6 +166,11 @@ class Fedot:
             with fedot_composer_timer.launch_preprocessing():
                 self.train_data = self.data_processor.fit_transform(self.train_data)
 
+        # ISSUE #1317 Quick Fix: Do not launch composition for Atomized Model
+        if init_asm := self.params.data.get('initial_assumption'):
+            if predefined_model is None and "atomized" in init_asm.descriptive_id: 
+                predefined_model = init_asm
+
         with fedot_composer_timer.launch_fitting():
             if predefined_model is not None:
                 # Fit predefined model and return it without composing

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -166,9 +166,11 @@ class Fedot:
             with fedot_composer_timer.launch_preprocessing():
                 self.train_data = self.data_processor.fit_transform(self.train_data)
 
+        # TODO: Workaround for AtomizedModel
         init_asm = self.params.data.get('initial_assumption')
         if predefined_model is None:
             if isinstance(init_asm, Pipeline) and ("atomized" in init_asm.descriptive_id):
+                self.log.message('Composition for AtomizedModel currently unavailable')
                 predefined_model = init_asm
 
         with fedot_composer_timer.launch_fitting():

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -166,10 +166,9 @@ class Fedot:
             with fedot_composer_timer.launch_preprocessing():
                 self.train_data = self.data_processor.fit_transform(self.train_data)
 
-        # ISSUE #1317 Quick Fix: Do not launch composition for Atomized Model
-        if init_asm := self.params.data.get('initial_assumption'):
-            if predefined_model is None and "atomized" in init_asm.descriptive_id:
-                predefined_model = init_asm
+        init_asm = self.params.data.get('initial_assumption')
+        if (predefined_model is None) and init_asm and ("atomized" in init_asm.descriptive_id):
+            predefined_model = init_asm
 
         with fedot_composer_timer.launch_fitting():
             if predefined_model is not None:

--- a/fedot/api/main.py
+++ b/fedot/api/main.py
@@ -168,7 +168,7 @@ class Fedot:
 
         # ISSUE #1317 Quick Fix: Do not launch composition for Atomized Model
         if init_asm := self.params.data.get('initial_assumption'):
-            if predefined_model is None and "atomized" in init_asm.descriptive_id: 
+            if predefined_model is None and "atomized" in init_asm.descriptive_id:
                 predefined_model = init_asm
 
         with fedot_composer_timer.launch_fitting():


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

Quick Fix: prevent launch pipeline composition for Atomized model.

Example notebook with Atomized Model works as expected:
https://github.com/aimclub/FEDOT/blob/master/examples/advanced/additional_learning.py

## Context

Fixes #1317

