### PR TITLE
Added a log message to clarify initial assumption fit time estimation

### DIFF
--- a/fedot/api/api_utils/api_composer.py
+++ b/fedot/api/api_utils/api_composer.py
@@ -110,7 +110,12 @@ class ApiComposer:
                                                                         eval_n_jobs=self.params.n_jobs)
 
         self.log.message(
-            f'Initial pipeline was fitted in {round(self.timer.assumption_fit_spend_time.total_seconds(), 1)} sec.')
+            f'Initial pipeline was fitted in '
+            f'{round(self.timer.assumption_fit_spend_time_single_fold.total_seconds(), 1)} sec.')
+
+        self.log.message(
+            f'Taking into account n_folds={self.params.data["cv_folds"]}, estimated fit time for initial assumption '
+            f'is {round(self.timer.assumption_fit_spend_time.total_seconds(), 1)} sec.')
 
         self.params.update(preset=assumption_handler.propose_preset(preset, self.timer, n_jobs=self.params.n_jobs))
 


### PR DESCRIPTION
This is a 🔨 code refactoring

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've performed a self-review of my code
  - I've linted my code locally before submission
  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
-->

## Summary

Initial pipeline fit time was displayed  in log as real fit time multiplied by _cv_folds_ (_cv_folds_ times longer)

Initial assumption fit time estimation is correct (takes into account _cv_folds_)

Added a message to log which clarifies initial assumption fit time estimation

<img width="1195" alt="Снимок экрана 2024-11-02 в 23 46 42" src="https://github.com/user-attachments/assets/c45b9561-2373-44fe-b21d-077fe80691b5">

## Context

  Closes #1332

