### PR TITLE
fix: Fix "last updated" date for edited PEP8 Action comment

### DIFF
--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -30,6 +30,9 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             Code in this pull request contains PEP8 errors, please write the `/fix-pep8` command in the comments below to create commit with automatic fixes.
+      - name: Retrieve current Date & Time in Moscow TimeZone
+        shell: bash
+        run: echo "TIMESTAMP=$(TZ=":Europe/Moscow" date -R|sed 's/.....$//')" >> $GITHUB_ENV
       - name: Update comment if NOT fixed
         if: ${{ steps.fc.outputs.comment-id != '' && steps.autopep8.outputs.exit-code == 2}}
         uses: peter-evans/create-or-update-comment@v3
@@ -39,7 +42,7 @@ jobs:
           body: |
             Code in this pull request **still** contains PEP8 errors, please write the `/fix-pep8` command in the comments below to create commit with automatic fixes.
 
-            ##### Comment last updated at ${{ github.event.head_commit.timestamp }}
+            ##### Comment last updated at ${{ env.TIMESTAMP }}
       - name: Update comment if fixed
         if: ${{ steps.fc.outputs.comment-id != '' && steps.autopep8.outputs.exit-code != 2}}
         uses: peter-evans/create-or-update-comment@v3
@@ -49,7 +52,7 @@ jobs:
           body: |
             All PEP8 errors has been fixed, thanks :heart:
 
-            ##### Comment last updated at ${{ github.event.head_commit.timestamp }}
+            ##### Comment last updated at ${{ env.TIMESTAMP }}
       - name: Fail if autopep8 made changes
         if: steps.autopep8.outputs.exit-code == 2
         run: exit 1


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

Should fix lack of datetime in GitHub action for pep8 bot.

Preview:
![image](https://github.com/user-attachments/assets/db8ab299-821b-41b9-92d6-8b8181519a5b)
Text example in https://github.com/DRMPN/FEDOT/pull/22

## Context

Fixes #1306
