### PR TITLE
fix: Telegram PR merge notification

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,10 +1,9 @@
-name: PR merge/close notification
+name: Telegram PR merge/close notification
 on:
   pull_request:
-    types: [ closed ]
+    types: [closed]
 
 jobs:
-
   merge_job:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
@@ -15,16 +14,17 @@ jobs:
         with:
           to: ${{ secrets.CHAT_ID }}
           token: ${{ secrets.TELEGRAM_TOKEN }}
-          message: "${{ github.event.repository.name }}: 
-          the ${{ github.event_name }} '${{ github.event.pull_request.title }}' 
-          (#${{ github.event.number }}) was merged.
-          \n[Link](${{ github.event.pull_request.html_url }}).
-          \nDescription:\n${{ github.event.pull_request.body }}
-          \n
-          \nCheck it out to keep your local repository updated."
           format: markdown
           disable_web_page_preview: true
+          message: |
+            ${{ github.event.repository.name }}: the PR [#${{ github.event.number }}](${{ github.event.pull_request.html_url }}) *"${{ github.event.pull_request.title }}"* was merged.
 
+            Description:
+            ```markdown
+            ${{ github.event.pull_request.body }}
+            ```
+
+            Check it out to keep your local repository updated!
 
   close_job:
     if: github.event.pull_request.merged == false
@@ -36,6 +36,7 @@ jobs:
         with:
           to: ${{ secrets.CHAT_ID }}
           token: ${{ secrets.TELEGRAM_TOKEN }}
-          message: "${{ github.event.repository.name }}: 
-          the ${{ github.event_name }} ${{ github.event.pull_request.title }} 
-          (${{ github.event.number }}) was closed."
+          format: markdown
+          disable_web_page_preview: true
+          message: |
+            ${{ github.event.repository.name }}: the PR [#${{ github.event.number }}](${{ github.event.pull_request.html_url }}) *"${{ github.event.pull_request.title }}"* was closed.

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,4 +1,4 @@
-name: Telegram PR merge/close notification
+name: Telegram PR merge notification
 on:
   pull_request:
     types: [closed]
@@ -25,18 +25,3 @@ jobs:
             ```
 
             Check it out to keep your local repository updated!
-
-  close_job:
-    if: github.event.pull_request.merged == false
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@master
-      - name: send custom message with args
-        uses: appleboy/telegram-action@master
-        with:
-          to: ${{ secrets.CHAT_ID }}
-          token: ${{ secrets.TELEGRAM_TOKEN }}
-          format: markdown
-          disable_web_page_preview: true
-          message: |
-            ${{ github.event.repository.name }}: the PR [#${{ github.event.number }}](${{ github.event.pull_request.html_url }}) *"${{ github.event.pull_request.title }}"* was closed.


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

Fixes formatting errors in Telegram notification messages.

Additionally:
- Changes the notification text.
- Removes the PR close notification.

Example:

![image](https://github.com/user-attachments/assets/8c29ff23-bc4e-4a5d-ba98-c9803fa8b9a0)

## Context

Fixes #1347
