### PR TITLE
Hotfix: pin scikit-learn version to <1.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ xgboost>=1.4.0 # to prevent warnings
 statsmodels>=0.12.0
 ete3>=3.1.0
 networkx>=2.4, !=2.7.*, !=2.8.1, !=2.8.2, !=2.8.3
-scikit_learn>=1.0.0; python_version >= '3.8'
+scikit-learn>=1.0.0,<1.6 ; python_version >= '3.8'
 sktime==0.16.1; python_version < '3.10'
 sktime>=0.16.1; python_version >= '3.10'
 


### PR DESCRIPTION
Видимо тесты попадали из-за новой версии scikit-learn, пока ограничил <1.6