### PR TITLE
chore: bump up golem dependency version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 scipy<1.13.0
 
 # Base framework
-thegolem @ git+https://github.com/aimclub/GOLEM.git@45215bf#egg=thegolem
+thegolem==0.4.1
 
 # Data
 numpy>=1.16.0, !=1.24.0


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

- [x] bump up `GOLEM` framework version in a project requirements file

## Context

This hotfix resolves the problem of conflicting dependencies in a virtual environment created using poetry during the most recent [Fedot.Industrial workflow](https://github.com/aimclub/Fedot.Industrial/actions/runs/13543064825/job/37848288836):
```
Failed to clone https://github.com/aimclub/GOLEM.git at '45215bf', verify ref exists on remote.
```
