### PR TITLE
Fix warnings in data types

### DIFF
--- a/fedot/preprocessing/data_types.py
+++ b/fedot/preprocessing/data_types.py
@@ -408,7 +408,7 @@ def define_column_types(table: Optional[np.ndarray]) -> pd.DataFrame:
     types, which column contains.
     """
     table_of_types = pd.DataFrame(table, copy=True)
-    table_of_types = table_of_types.replace({np.nan: None}).map(lambda el: TYPE_TO_ID[type(el)])
+    table_of_types = table_of_types.replace({np.nan: None}).applymap(lambda el: TYPE_TO_ID[type(el)])
 
     # Build dataframe with unique types for each column
     uniques = table_of_types.apply(pd.unique, result_type='reduce').to_frame(_TYPES).T

--- a/fedot/preprocessing/data_types.py
+++ b/fedot/preprocessing/data_types.py
@@ -103,7 +103,7 @@ class TableTypesCorrector:
         is_nan = pd.isnull(data.features)
         columns_with_all_nan = np.all(is_nan, axis=0)
         empty_columns = np.where(columns_with_all_nan)[0]
-        if empty_columns:
+        if empty_columns.size > 0:
             for col in empty_columns:
                 self.string_columns_transformation_failed.setdefault(col, None)
 
@@ -408,7 +408,7 @@ def define_column_types(table: Optional[np.ndarray]) -> pd.DataFrame:
     types, which column contains.
     """
     table_of_types = pd.DataFrame(table, copy=True)
-    table_of_types = table_of_types.replace({np.nan: None}).applymap(lambda el: TYPE_TO_ID[type(el)])
+    table_of_types = table_of_types.replace({np.nan: None}).map(lambda el: TYPE_TO_ID[type(el)])
 
     # Build dataframe with unique types for each column
     uniques = table_of_types.apply(pd.unique, result_type='reduce').to_frame(_TYPES).T
@@ -422,7 +422,7 @@ def define_column_types(table: Optional[np.ndarray]) -> pd.DataFrame:
     }
     types_counts = (
         table_of_types
-        .apply(pd.value_counts, dropna=False)
+        .apply(lambda col: col.value_counts(dropna=False))
         .reindex(counts_index_mapper.keys(), copy=False)  # Sets all type ids
         .replace(np.nan, 0)
         .rename(index=counts_index_mapper, copy=False)  # Renames all type ids to strs


### PR DESCRIPTION
# PR Summary
This small PR resolves the following two annoying warnings coming from `fedot/preprocessing/data_types.py`: 
```python
/tmp/FEDOT/fedot/preprocessing/data_types.py:425: FutureWarning: pandas.value_counts is deprecated and will be removed in a future version. Use pd.Series(obj).value_counts() instead.
    .apply(pd.value_counts, dropna=False)

/tmp/FEDOT/fedot/preprocessing/data_types.py:106: DeprecationWarning: The truth value of an empty array is ambiguous. Returning False, but in future this will result in an error. Use `array.size > 0` to check that an array is not empty.
    if empty_columns:
```