### PR TITLE
fix: multi-target prediction without target in InputData

### DIFF
--- a/fedot/core/operations/evaluation/evaluation_interfaces.py
+++ b/fedot/core/operations/evaluation/evaluation_interfaces.py
@@ -269,7 +269,7 @@ class SkLearnEvaluationStrategy(EvaluationStrategy):
             if n_classes < 2:
                 raise ValueError('Data set contain only 1 target class. Please reformat your data.')
             elif n_classes == 2 and self.output_mode != 'full_probs':
-                if is_multi_output_target:
+                if is_multi_output_model(self.operation_impl):
                     prediction = np.stack([pred[:, 1] for pred in prediction]).T
                 else:
                     prediction = prediction[:, 1]

--- a/fedot/core/operations/evaluation/evaluation_interfaces.py
+++ b/fedot/core/operations/evaluation/evaluation_interfaces.py
@@ -32,6 +32,7 @@ from fedot.core.operations.operation_parameters import OperationParameters
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.operation_types_repository import OperationTypesRepository, get_operation_type_from_id
 from fedot.core.repository.tasks import TaskTypesEnum
+from fedot.core.utils import is_multi_output_target, is_multi_output_model
 from fedot.utilities.custom_errors import AbstractMethodNotImplementError
 from fedot.utilities.random import ImplementationRandomStateHandler
 
@@ -221,7 +222,9 @@ class SkLearnEvaluationStrategy(EvaluationStrategy):
         is_model_not_support_multi = self.operation_type in non_multi_models
 
         # Multi-output task or not
-        is_multi_target = is_multi_output_task(train_data)
+        is_multi_target = is_multi_output_target(train_data)
+        self.operation_impl.is_multi_target = is_multi_target
+
         with ImplementationRandomStateHandler(implementation=operation_implementation):
             if is_model_not_support_multi and is_multi_target:
                 # Manually wrap the regressor into multi-output model
@@ -254,9 +257,8 @@ class SkLearnEvaluationStrategy(EvaluationStrategy):
         return str(self._convert_to_operation(self.operation_type))
 
     def _sklearn_compatible_prediction(self, trained_operation, features):
-        is_multi_output_target = isinstance(trained_operation.classes_, list)
         # Check if target is multilabel (has 2 or more columns)
-        if is_multi_output_target:
+        if is_multi_output_model(self.operation_impl):
             n_classes = len(trained_operation.classes_[0])
         else:
             n_classes = len(trained_operation.classes_)
@@ -299,10 +301,3 @@ def convert_to_multivariate_model(sklearn_model, train_data: InputData):
     sklearn_model = multiout_func(sklearn_model)
     sklearn_model.fit(train_data.features, train_data.target)
     return sklearn_model
-
-
-def is_multi_output_task(train_data):
-    if train_data.target is not None:
-        target_shape = train_data.target.shape
-        is_multi_target = len(target_shape) > 1 and target_shape[1] > 1
-        return is_multi_target

--- a/fedot/core/operations/evaluation/operation_implementations/implementation_interfaces.py
+++ b/fedot/core/operations/evaluation/operation_implementations/implementation_interfaces.py
@@ -206,6 +206,7 @@ class ModelImplementation(ABC):
     def __init__(self, params: OperationParameters = None):
         self.log = default_log(self)
         self.params = params or OperationParameters()
+        self.is_multi_target: bool = False
 
     @abstractmethod
     def fit(self, input_data: InputData):

--- a/fedot/core/operations/evaluation/operation_implementations/models/boostings_implementations.py
+++ b/fedot/core/operations/evaluation/operation_implementations/models/boostings_implementations.py
@@ -14,8 +14,7 @@ from fedot.core.data.data import InputData
 from fedot.core.data.data_split import train_test_data_setup
 from fedot.core.operations.evaluation.operation_implementations.implementation_interfaces import ModelImplementation
 from fedot.core.operations.operation_parameters import OperationParameters
-from fedot.core.utils import default_fedot_data_dir
-from fedot.core.operations.evaluation.evaluation_interfaces import is_multi_output_task
+from fedot.core.utils import default_fedot_data_dir, is_multi_output_target
 from fedot.core.repository.tasks import TaskTypesEnum
 
 
@@ -186,7 +185,7 @@ class FedotLightGBMImplementation(ModelImplementation):
                 self.model._other_params.update(early_stopping_rounds=None)
                 self.params.update(early_stopping_rounds=None)
 
-            if is_multi_output_task(input_data):
+            if is_multi_output_target(input_data):
                 self._convert_to_multi_output_model(input_data)
 
             # Training model without splitting on train and eval
@@ -400,7 +399,7 @@ def convert_to_dataframe(data: Optional[InputData], identify_cats: bool):
     features = pd.DataFrame(data=data.features)
 
     if data.target is not None and data.target.size > 0:
-        if not is_multi_output_task(data):
+        if not is_multi_output_target(data):
             target = np.ravel(data.target[:features.shape[0]])
         else:
             target = data.target
@@ -427,7 +426,7 @@ def check_eval_set_condition(input_data: InputData, params: OperationParameters)
     Checks the model training condition with eval_set.
     """
     is_using_eval_set = bool(params.get('use_eval_set'))
-    if not is_using_eval_set or is_multi_output_task(input_data):
+    if not is_using_eval_set or is_multi_output_target(input_data):
         return False
 
     # No special conditions for regression task

--- a/fedot/core/utils.py
+++ b/fedot/core/utils.py
@@ -11,6 +11,8 @@ import pandas as pd
 from golem.utilities.random import RandomStateHandler
 from sklearn.model_selection import train_test_split
 
+from fedot.core.data.data import InputData
+
 DEFAULT_PARAMS_STUB = 'default_params'
 NESTED_PARAMS_LABEL = 'nested_space'
 
@@ -133,3 +135,15 @@ def convert_memory_size(size_bytes):
     byte_digit = math.pow(1024, integer_size_value)
     size_in_digit_name = round(size_bytes / byte_digit, 2)
     return "%s %s" % (size_in_digit_name, digit_name[integer_size_value])
+
+
+def is_multi_output_target(train_data: InputData) -> bool:
+    """Determine if the task is multi-output based on target shape."""
+    if train_data.target is not None:
+        return len(train_data.target.shape) > 1 and train_data.target.shape[1] > 1
+    return False
+
+
+def is_multi_output_model(operation_impl) -> bool:
+    """Check if operation is configured for multi-output target."""
+    return getattr(operation_impl, 'is_multi_target', False)


### PR DESCRIPTION
This is a 🐛 bug fix.


## Summary

Multi-target classification fails during the `.predict()` operation if the input data lacks a target column. To address this, the multi-output mode state is now stored as a dynamically added in the `ModelImplementation` class. This allows the output behavior to be controlled via a model property rather than inferred from input data.

## Context

  Fixes #1391

