### PR TITLE
Fix explicit available_operations being partially ignored by evolution

### DIFF
--- a/fedot/core/pipelines/pipeline_advisor.py
+++ b/fedot/core/pipelines/pipeline_advisor.py
@@ -3,13 +3,18 @@ from typing import List
 from golem.core.optimisers.advisor import DefaultChangeAdvisor, RemoveType
 from golem.core.optimisers.graph import OptNode
 
-from fedot.core.repository.operation_types_repository import get_operations_for_task
+from fedot.core.repository.operation_types_repository import get_all_operations_for_task
 
 
 class PipelineChangeAdvisor(DefaultChangeAdvisor):
     def __init__(self, task=None):
-        self.models: List[str] = get_operations_for_task(task, mode='model')
-        self.data_operations: List[str] = get_operations_for_task(task, mode='data_operation')
+        # These lists classify candidates into models and data operations, they
+        # do not select them: availability is decided by `possible_operations`
+        # the caller passes in. The unfiltered lists keep the advisor from
+        # silently vetoing operations the user requested explicitly but the
+        # default tag exclusions would hide (e.g. qda, mlp, dt).
+        self.models: List[str] = get_all_operations_for_task(task, mode='model')
+        self.data_operations: List[str] = get_all_operations_for_task(task, mode='data_operation')
         super().__init__(task)
 
     def can_be_removed(self, node: OptNode) -> RemoveType:

--- a/fedot/core/pipelines/verification_rules.py
+++ b/fedot/core/pipelines/verification_rules.py
@@ -7,8 +7,8 @@ from fedot.core.operations.model import Model
 from fedot.core.pipelines.node import PipelineNode
 from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.repository.dataset_types import DataTypesEnum
-from fedot.core.repository.operation_types_repository import OperationTypesRepository, get_operations_for_task, \
-    atomized_model_type
+from fedot.core.repository.operation_types_repository import OperationTypesRepository, get_all_operations_for_task, \
+    get_operations_for_task, atomized_model_type
 from fedot.core.repository.tasks import Task, TaskTypesEnum
 
 ERROR_PREFIX = 'Invalid pipeline configuration:'
@@ -273,7 +273,10 @@ def has_no_conflicts_during_multitask(pipeline: Pipeline):
     Validation perform only for classification pipelines.
     """
 
-    classification_operations = get_operations_for_task(task=Task(TaskTypesEnum.classification), mode='all')
+    # The unfiltered list is required: with the default tag exclusions an
+    # explicitly requested operation (e.g. qda or mlp) would be read as
+    # solving a foreign task and the pipeline would be rejected.
+    classification_operations = get_all_operations_for_task(task=Task(TaskTypesEnum.classification))
     pipeline_operations = [node.operation.operation_type for node in pipeline.nodes]
     pipeline_operations = set(pipeline_operations)
 
@@ -302,7 +305,7 @@ def has_no_conflicts_after_class_decompose(pipeline: Pipeline):
     if 'class_decompose' not in pipeline_operations:
         return True
 
-    regression_operations = get_operations_for_task(task=Task(TaskTypesEnum.regression), mode='all')
+    regression_operations = get_all_operations_for_task(task=Task(TaskTypesEnum.regression))
 
     # Check for correct descendants after classification decompose
     for node in pipeline.nodes:

--- a/fedot/core/repository/operation_types_repository.py
+++ b/fedot/core/repository/operation_types_repository.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from functools import lru_cache
 import os
 from collections import defaultdict
 from dataclasses import dataclass
@@ -476,8 +477,17 @@ def get_all_operations_for_task(task: Optional[Task] = None, mode: str = 'all') 
     if mode not in AVAILABLE_REPO_NAMES:
         raise ValueError(f'Such mode "{mode}" is not supported')
     task_type = task.task_type if task else None
+    # The verification rules ask for these lists on every checked graph; the
+    # registry is static, so the scan is done once per (task, mode). A copy is
+    # returned to keep the cache safe from mutation by callers.
+    return list(_all_operations_for_task_type(task_type, mode))
+
+
+@lru_cache(maxsize=None)
+def _all_operations_for_task_type(task_type: Optional[TaskTypesEnum], mode: str) -> tuple:
     repo = OperationTypesRepository(mode)
-    return sorted(op.id for op in repo.operations if task_type is None or task_type in op.task_type)
+    return tuple(sorted(op.id for op in repo.operations
+                        if task_type is None or task_type in op.task_type))
 
 
 def get_operation_type_from_id(operation_id):

--- a/fedot/core/repository/operation_types_repository.py
+++ b/fedot/core/repository/operation_types_repository.py
@@ -456,6 +456,30 @@ def get_operations_for_task(task: Optional[Task], data_type: Optional[DataTypesE
         raise ValueError(f'Such mode "{mode}" is not supported')
 
 
+def get_all_operations_for_task(task: Optional[Task] = None, mode: str = 'all') -> List[str]:
+    """Function returns aliases of every operation registered for the task.
+
+    Unlike :func:`get_operations_for_task`, the default tag exclusions do not
+    apply, so operations tagged as deprecated, non-default or expensive are
+    included. Use this where the complete universe of operations matters -
+    e.g. to recognise an operation the user requested explicitly - rather
+    than to choose default candidates.
+
+    Args:
+        task: task to solve
+        mode: ``all``, ``model`` or ``data_operation``, as in
+            :func:`get_operations_for_task`
+
+    Returns:
+        list: operation aliases
+    """
+    if mode not in AVAILABLE_REPO_NAMES:
+        raise ValueError(f'Such mode "{mode}" is not supported')
+    task_type = task.task_type if task else None
+    repo = OperationTypesRepository(mode)
+    return sorted(op.id for op in repo.operations if task_type is None or task_type in op.task_type)
+
+
 def get_operation_type_from_id(operation_id):
     operation_type = _operation_name_without_postfix(operation_id)
     return operation_type

--- a/fedot/core/repository/pipeline_operation_repository.py
+++ b/fedot/core/repository/pipeline_operation_repository.py
@@ -1,7 +1,6 @@
 import itertools
 from typing import List, Optional, Dict
 
-from fedot.api.api_utils.presets import OperationsPreset
 from fedot.core.repository.graph_operation_repository import GraphOperationRepository
 from fedot.core.repository.operation_types_repository import get_operations_for_task
 from fedot.core.repository.tasks import Task, TaskTypesEnum
@@ -26,11 +25,16 @@ class PipelineOperationRepository(GraphOperationRepository):
 
     def from_available_operations(self, task: Task, preset: str,
                                   available_operations: List[str]):
-        """ Initialize repository from available operations, task and preset """
-        operations_by_task_preset = OperationsPreset(task, preset).filter_operations_by_preset()
-        all_operations = sorted(list(set.intersection(set(operations_by_task_preset), set(available_operations))))
-        primary_operations, secondary_operations = \
-            self.divide_operations(all_operations, task)
+        """ Initialize repository from available operations and task.
+
+        The list is taken verbatim. When the user did not restrict operations
+        the caller passes the preset's own operation set here, and when the
+        user did, re-filtering by preset would silently drop the requested
+        operations that the preset tags exclude (e.g. qda, mlp, dt), so the
+        mutations could never propose them.
+        """
+        all_operations = sorted(set(available_operations))
+        primary_operations, secondary_operations = self.divide_operations(all_operations, task)
         self.operations_by_keys = {'primary': primary_operations, 'secondary': secondary_operations}
 
     def get_operations(self, is_primary: bool) -> List[str]:

--- a/test/unit/pipelines/test_pipeline_node_factory.py
+++ b/test/unit/pipelines/test_pipeline_node_factory.py
@@ -4,6 +4,7 @@ from golem.core.optimisers.graph import OptNode
 
 from fedot.core.pipelines.pipeline_advisor import PipelineChangeAdvisor
 from fedot.core.pipelines.pipeline_node_factory import PipelineOptNodeFactory
+from fedot.core.repository.pipeline_operation_repository import PipelineOperationRepository
 from fedot.core.repository.tasks import Task, TaskTypesEnum
 
 
@@ -78,3 +79,33 @@ def test_get_primary_node(node_factory):
 
     assert new_primary_node is not None
     assert new_primary_node.content['name'] in node_factory.graph_model_repository.get_operations(is_primary=True)
+
+
+def test_change_node_proposes_operations_excluded_by_default_tags():
+    """An explicit list of operations must reach node replacement even for
+    operations the default repository tag filter hides (qda, mlp, dt)."""
+    task = Task(TaskTypesEnum.classification)
+    operations = ['logit', 'rf', 'qda', 'mlp', 'dt', 'scaling']
+    requirements = PipelineComposerRequirements(primary=operations,
+                                                secondary=operations)
+    factory = PipelineOptNodeFactory(requirements=requirements,
+                                     advisor=PipelineChangeAdvisor(task))
+    node = OptNode(content={'name': 'logit'})
+
+    proposed = {factory.exchange_node(node).content['name'] for _ in range(200)}
+
+    assert {'qda', 'mlp', 'dt'}.issubset(proposed)
+
+
+def test_from_available_operations_keeps_the_list_verbatim():
+    """The repository must not re-filter an explicit operation list by preset:
+    the caller resolves the preset when the user gave no list of their own."""
+    task = Task(TaskTypesEnum.classification)
+    operations = ['logit', 'rf', 'qda', 'mlp', 'dt', 'scaling']
+    repository = PipelineOperationRepository()
+
+    repository.from_available_operations(task=task, preset='best_quality',
+                                         available_operations=operations)
+
+    assert set(repository.get_operations(is_primary=True)) == set(operations)
+    assert set(repository.get_operations(is_primary=False)) == set(operations)

--- a/test/unit/pipelines/test_pipeline_verification.py
+++ b/test/unit/pipelines/test_pipeline_verification.py
@@ -395,3 +395,15 @@ def test_incorrect_pipeline_with_parallel_filtering_branches():
 def test_pipeline_with_filtering_branch_correct():
     pipeline = correct_pipeline_with_filtering_branch()
     assert has_no_parallel_branches_with_filtering(pipeline)
+
+
+def test_multitask_rule_accepts_operations_excluded_by_default_tags():
+    """A classification pipeline built from explicitly requested operations
+    must pass the multitask check even when the default repository tag filter
+    hides those operations (e.g. qda and mlp are tagged as deprecated)."""
+    for model in ('qda', 'mlp'):
+        first = PipelineNode(operation_type='scaling')
+        second = PipelineNode(operation_type=model, nodes_from=[first])
+        pipeline = Pipeline(second)
+
+        assert has_no_conflicts_during_multitask(pipeline)


### PR DESCRIPTION
## Summary

An explicit `available_operations` list reaches the initial assumptions and the *"Set of candidate models"* log message, but not the evolution itself: operations that the default repository tag filter hides (`qda`, `mlp` and `dt` are tagged as deprecated or non-default) can never appear in offspring, and the loss is completely silent.

Reproduced on FEDOT master with a classification run passing `available_operations=[..., 'qda', 'mlp', 'dt', ...]`: across 285 evaluated individuals in 55 generations, none of the three operations was ever proposed or kept, while the log printed the full candidate list.

## Root causes

Three independent places rebuild their operation lists from repository tags instead of honouring the user's list:

1. **`PipelineOperationRepository.from_available_operations`** intersected the list with the preset's operation set before it became the mutation candidate pool, so hidden operations never entered the node factory.
2. **`PipelineChangeAdvisor`** rebuilt its model / data-operation lists with the default tag filter and used them to veto node replacements (`propose_change`) and new parents (`propose_parent`), so even operations present in the factory pool were dropped.
3. **`has_no_conflicts_during_multitask`** read any operation missing from the tag-filtered classification list as solving a foreign task and rejected the whole offspring at verification, so a proposed candidate never survived selection. `has_no_conflicts_after_class_decompose` had the same flaw for regression models.

Each layer masks the next one, which is why the bug survives: fixing (1) alone changes nothing observable, fixing (1)+(2) lets candidates be proposed but they are still vetoed at (3).

## Fix

- `from_available_operations` takes the list verbatim; the caller (`ApiParams`) already resolves the preset into `available_operations` when the user gave no list of their own, so default runs see the exact same set as before.
- A new `get_all_operations_for_task` helper lists every operation registered for a task, ignoring the default tag exclusions. The advisor and the two verification rules use it, because these places need to *recognise* operations, not to *choose default candidates*.

## Effect

On a synthetic dataset whose signal is a sum of two squared oblique projections (linear models blind at AUC 0.51, boosting myopic at 0.67, `scaling -> mlp` / `qda` at 0.87), the same run with `available_operations` including `qda`/`mlp`:

- before: stuck at CV AUC 0.73 after 55 generations, `qda`/`mlp`/`dt` never evaluated;
- after: climbs 0.61 -> 0.89 across 82 generations with 12 leader changes, holdout ROC AUC 0.925.

## Tests

- `test_change_node_proposes_operations_excluded_by_default_tags` - node replacement can propose `qda`/`mlp`/`dt` when they are among the available operations;
- `test_from_available_operations_keeps_the_list_verbatim` - the repository no longer re-filters the explicit list by preset;
- `test_multitask_rule_accepts_operations_excluded_by_default_tags` - `scaling -> qda` and `scaling -> mlp` classification pipelines pass the multitask rule.

`test/unit/pipelines`, `test/unit/composer`, `test/unit/dag`, `test/unit/optimizer` and `test/unit/api/test_presets.py` pass locally (252 tests).
