### PR TITLE
Propose only models for the pipeline's final position

### DIFF
--- a/fedot/core/pipelines/pipeline_advisor.py
+++ b/fedot/core/pipelines/pipeline_advisor.py
@@ -12,6 +12,10 @@ class PipelineChangeAdvisor(DefaultChangeAdvisor):
         self.data_operations: List[str] = get_operations_for_task(task, mode='data_operation')
         super().__init__(task)
 
+    def can_be_sink(self, node: OptNode) -> bool:
+        """A pipeline must end with a model, so only models fit the sink."""
+        return node.content['name'] in self.models
+
     def can_be_removed(self, node: OptNode) -> RemoveType:
         operation_id = node.content['name']
         if 'exog_ts' in operation_id:

--- a/fedot/core/pipelines/pipeline_node_factory.py
+++ b/fedot/core/pipelines/pipeline_node_factory.py
@@ -51,6 +51,20 @@ class PipelineOptNodeFactory(OptNodeFactory):
         candidates = self.filter_specific_candidates(candidates)
         return self._return_node(candidates)
 
+    def get_final_node(self):
+        """A node fit to end the pipeline: models only.
+
+        Mutations ask for this when the new node becomes the sink. Proposing a
+        data operation there is pointless - ``has_final_operation_as_model``
+        rejects the whole offspring at verification - and such proposals used
+        to be the main source of discarded mutants.
+        """
+        candidates = self.graph_model_repository.get_operations(is_primary=False)
+        models = set(self.advisor.models)
+        candidates = [candidate for candidate in candidates if candidate in models]
+        candidates = self.filter_specific_candidates(candidates)
+        return self._return_node(candidates)
+
     @staticmethod
     def _return_node(candidates) -> Optional[OptNode]:
         if not candidates:

--- a/test/unit/pipelines/test_pipeline_node_factory.py
+++ b/test/unit/pipelines/test_pipeline_node_factory.py
@@ -87,3 +87,11 @@ def test_get_final_node_proposes_models_only(node_factory):
         node = node_factory.get_final_node()
         assert node is not None
         assert node.content['name'] in ('dt', 'logit', 'rf')
+
+
+def test_advisor_accepts_only_models_as_sink():
+    advisor = PipelineChangeAdvisor(Task(TaskTypesEnum.classification))
+    assert advisor.can_be_sink(OptNode(content={'name': 'rf'}))
+    assert advisor.can_be_sink(OptNode(content={'name': 'logit'}))
+    assert not advisor.can_be_sink(OptNode(content={'name': 'scaling'}))
+    assert not advisor.can_be_sink(OptNode(content={'name': 'pca'}))

--- a/test/unit/pipelines/test_pipeline_node_factory.py
+++ b/test/unit/pipelines/test_pipeline_node_factory.py
@@ -78,3 +78,12 @@ def test_get_primary_node(node_factory):
 
     assert new_primary_node is not None
     assert new_primary_node.content['name'] in node_factory.graph_model_repository.get_operations(is_primary=True)
+
+
+def test_get_final_node_proposes_models_only(node_factory):
+    """The sink of a pipeline must be a model; the factory must never propose
+    a data operation there, because verification would reject the offspring."""
+    for _ in range(50):
+        node = node_factory.get_final_node()
+        assert node is not None
+        assert node.content['name'] in ('dt', 'logit', 'rf')


### PR DESCRIPTION
## Summary

Implements `get_final_node` introduced in aimclub/GOLEM#294 for the pipeline node factory: only models are proposed for the pipeline's final position.

A census of a fixed-work composition (12 generations, population 24) showed **73 % of mutated offspring rejected at verification, 89 % of them by `has_final_operation_as_model`**: the add-as-child mutation places a new node in the sink position, and the factory proposed any secondary operation there, including preprocessing. Such offspring are always rejected, so proposing them only burns a graph copy, a mutation and a verification per attempt.

The search space is unchanged — every proposal this removes was impossible to accept. Until the GOLEM side is merged the new method is simply never called, so this is safe to merge independently.

`test/unit/pipelines/test_pipeline_node_factory.py` passes, including a new test that the final position only ever receives models.