### PR TITLE
chore: declare giotto-ph in extra requirements instead of unused ripser and giotto_tda

### DIFF
--- a/other_requirements/extra.txt
+++ b/other_requirements/extra.txt
@@ -15,5 +15,4 @@ nltk==3.8.1
 protobuf~=3.19.0
 
 # Topological features
-giotto_tda==0.6.0
-ripser==0.6.4
+giotto-ph==0.2.4


### PR DESCRIPTION
Closes #1450

## What changed

`other_requirements/extra.txt`: replaced `giotto_tda==0.6.0` and `ripser==0.6.4` with `giotto-ph==0.2.4`, which is the distribution actually imported by the topological features code.

1 file changed, +1/-2.

The version is pinned exactly, following the style of the surrounding entries in the same file.

## Why

`fedot/core/operations/evaluation/operation_implementations/data_operations/topological/fast_topological_extractor.py:8` and `fedot/core/repository/operation_types_repository.py:19` both do `from gph import ripser_parallel as ripser`. No module in the repository imports the `ripser` distribution or `gtda`; the identifier `ripser` in the source is a local alias for `gph.ripser_parallel`.

Until now `giotto-ph` reached the environment only as a transitive dependency of `giotto-tda`, so `fedot[extra]` worked without declaring what it uses. Declaring it directly removes that dependence on another project's dependency set.

No behaviour changes.

Per the contribution guide's checklist for dependency changes: `giotto-ph` installs from pre-built wheels on Linux, macOS and Windows (554 kB for cp310 manylinux), requires no compiler, and its own requirements — numpy, scipy, scikit-learn — are already direct FEDOT dependencies. It is already installed in every `fedot[extra]` environment as a transitive dependency of `giotto-tda`, so installation complexity is unchanged. The entry belongs in `other_requirements/extra.txt` rather than `requirements.txt` because the topological operation is an extra.

## Verification

```
python -m pytest test/unit -q                       647 passed, 1718 warnings in 292.01s
grep -rn -E "\bripser\b|\bgtda\b" --include=*.py \
     --include=*.rst --include=*.md --include=*.ipynb .   only gph.ripser_parallel call sites
```

The suite above was run in a fresh environment built as this change describes — `pip install -e .`, then `pip install pytest giotto-ph==0.2.4`, with neither `giotto-tda` nor `ripser` present. All 647 unit tests pass, including `test_positive_window_size_in_fast_topo` and `test_topological_node`, which are the tests that exercise the topological operation.

For comparison, the same checkout without `giotto-ph` installed reports `4 failed, 643 passed`, all four failing with `NameError: name 'ripser' is not defined`.

Environment: Python 3.10.21, Linux (WSL2), editable install.
