### PR TITLE
chore: remove unreachable operation entries left by the xgbreg rename

### DIFF
--- a/fedot/api/builder.py
+++ b/fedot/api/builder.py
@@ -305,7 +305,7 @@ class FedotBuilder:
                     - ``svr`` -> Linear Support Vector Regressor
                     - ``treg`` -> Extra Trees Regressor
                     - ``xgboost`` -> Extreme Gradient Boosting Classifier
-                    - ``xgbreg`` -> Extreme Gradient Boosting Regressor
+                    - ``xgboostreg`` -> Extreme Gradient Boosting Regressor
                     - ``cnn`` -> Convolutional Neural Network
                     - ``scaling`` -> Scaling
                     - ``normalization`` -> Normalization
@@ -357,7 +357,7 @@ class FedotBuilder:
                     - ``ridge`` -> Ridge Linear Regressor
                     - ``treg`` -> Extra Trees Regressor
                     - ``xgboost`` -> Extreme Gradient Boosting Classifier
-                    - ``xgbreg`` -> Extreme Gradient Boosting Regressor
+                    - ``xgboostreg`` -> Extreme Gradient Boosting Regressor
 
             max_depth: max depth of a pipeline. Defaults to ``6``.
 

--- a/fedot/core/operations/evaluation/evaluation_interfaces.py
+++ b/fedot/core/operations/evaluation/evaluation_interfaces.py
@@ -4,8 +4,6 @@ from typing import Optional
 
 import numpy as np
 from golem.core.log import default_log
-from lightgbm.sklearn import LGBMClassifier, LGBMRegressor
-from sklearn.cluster import KMeans as SklearnKmeans
 from sklearn.ensemble import (
     AdaBoostRegressor,
     ExtraTreesRegressor,
@@ -25,7 +23,6 @@ from sklearn.naive_bayes import BernoulliNB as SklearnBernoulliNB, MultinomialNB
 from sklearn.neural_network import MLPClassifier
 from sklearn.svm import LinearSVR as SklearnSVR
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
-from xgboost import XGBClassifier, XGBRegressor
 
 from fedot.core.data.data import InputData, OutputData
 from fedot.core.operations.operation_parameters import OperationParameters
@@ -145,7 +142,6 @@ class SkLearnEvaluationStrategy(EvaluationStrategy):
 
             .. details:: possible operations:
 
-                - ``xgbreg``-> XGBRegressor
                 - ``adareg``-> AdaBoostRegressor
                 - ``gbr``-> GradientBoostingRegressor
                 - ``dtreg``-> DecisionTreeRegressor
@@ -156,22 +152,17 @@ class SkLearnEvaluationStrategy(EvaluationStrategy):
                 - ``lasso``-> SklearnLassoReg
                 - ``svr``-> SklearnSVR
                 - ``sgdr``-> SklearnSGD
-                - ``lgbmreg``-> LGBMRegressor
-                - ``xgboost``-> XGBClassifier
                 - ``logit``-> SklearnLogReg
                 - ``bernb``-> SklearnBernoulliNB
                 - ``multinb``-> SklearnMultinomialNB
                 - ``dt``-> DecisionTreeClassifier
                 - ``rf``-> RandomForestClassifier
                 - ``mlp``-> MLPClassifier
-                - ``lgbm``-> LGBMClassifier
-                - ``kmeans``-> SklearnKmeans
 
         params: hyperparameters to fit the operation with
     """
 
     _operations_by_types = {
-        'xgbreg': XGBRegressor,
         'adareg': AdaBoostRegressor,
         'gbr': GradientBoostingRegressor,
         'dtreg': DecisionTreeRegressor,
@@ -182,18 +173,13 @@ class SkLearnEvaluationStrategy(EvaluationStrategy):
         'lasso': SklearnLassoReg,
         'svr': SklearnSVR,
         'sgdr': SklearnSGD,
-        'lgbmreg': LGBMRegressor,
 
-        'xgboost': XGBClassifier,
         'logit': SklearnLogReg,
         'bernb': SklearnBernoulliNB,
         'multinb': SklearnMultinomialNB,
         'dt': DecisionTreeClassifier,
         'rf': RandomForestClassifier,
         'mlp': MLPClassifier,
-        'lgbm': LGBMClassifier,
-
-        'kmeans': SklearnKmeans,
     }
 
     def __init__(self, operation_type: str, params: Optional[OperationParameters] = None):


### PR DESCRIPTION
Refs #1452

## What changed

`fedot/core/operations/evaluation/evaluation_interfaces.py`: removed five unreachable entries from `SkLearnEvaluationStrategy._operations_by_types` (`xgbreg`, `xgboost`, `lgbm`, `lgbmreg`, `kmeans`), the three module-level imports kept alive only by them, and the matching lines of the class docstring.

`fedot/api/builder.py`: `xgbreg` -> `xgboostreg` in the two docstrings listing available operations.

2 files changed, +2/-16.

The remaining no-behaviour-change item from the issue — the outdated `test/data/model_repository.json` fixture — is left out deliberately. Renaming its `xgbreg` entry alone would not be correct, since `xgboostreg` needs `meta: boosting_regr`, and adding metadata to test data is a larger change than this PR should carry.

## Why

Strategies are resolved as operation -> `meta` -> `strategies` in the repository metadata. Only 16 operations reach `SkLearnEvaluationStrategy` that way, through `sklearn_class` and `sklearn_regr`. The five removed keys cannot:

- `xgbreg` is not declared in any repository JSON. It was renamed to `xgboostreg` in #1209 (`80eba8ef`), which migrated XGBoost to `BoostingStrategy` but left this dict untouched.
- `xgboost`, `lgbm` and `lgbmreg` are declared under `boosting_class` / `boosting_regr` and served by `BoostingStrategy`, also since #1209.
- `kmeans` is declared under `sklearn_clust`, served by `SkLearnClusteringStrategy`, which overrides `_operations_by_types` with its own `kmeans` entry.

`SkLearnClassificationStrategy` and `SkLearnRegressionStrategy` do not override the dict and share this one, so nothing else could reach the removed keys either. `SkLearnClusteringStrategy` and `CuMLEvaluationStrategy` override it in full.

Those five entries were the only users of `from xgboost import XGBClassifier, XGBRegressor`, `from lightgbm.sklearn import LGBMClassifier, LGBMRegressor` and `from sklearn.cluster import KMeans as SklearnKmeans` in this module. Both packages stay required by `boostings_implementations.py`, and `clustering.py` imports `KMeans` independently, so no dependency and no other module is affected — this only drops an eager import of XGBoost and LightGBM from a module most of the operation layer pulls in.

The `builder.py` docstrings listed `xgbreg` among available operations. A user copying that name into `available_operations` gets a name no repository can resolve.

No behaviour changes.

Per the contribution guide: no new dependency, no new behaviour, so no new unit tests; docstrings updated together with the code they describe.

## Verification

```
python -m pytest test/unit -q
    647 passed, 1718 warnings in 271.65s (0:04:31)
flake8 --max-line-length=120 fedot/core/operations/evaluation/evaluation_interfaces.py
    no output
python -c "import fedot.api.main"
    ok
grep -rn "xgbreg" --include=*.py fedot/
    fedot/core/operations/hyperparameters_preprocessing.py:40:        'xgbreg': {
```

The same suite on the unmodified branch at `26f3af03` also reports `647 passed`, so this PR changes no test outcome. The remaining `xgbreg` occurrence is the hyperparameter preprocessing rule discussed in #1452, which changes behaviour and is left for a separate PR.

`flake8` also reports one pre-existing E501 at `fedot/api/builder.py:235`, in a docstring line unrelated to this change (`use_predictions_cache`). It is left as is. Since `.pep8speaks.yml` runs with `diff_only: False`, it may be reported against this PR.

Environment: Python 3.10.21, Linux (WSL2), editable install.
