### PR TITLE
fix: restore hyperparameter rules and bounds for xgboostreg

### DIFF
--- a/fedot/core/operations/hyperparameters_preprocessing.py
+++ b/fedot/core/operations/hyperparameters_preprocessing.py
@@ -37,7 +37,7 @@ class HyperparametersPreprocessor:
             'max_leaf_nodes': ['le0_to_none', 'integer'],
             'max_depth': ['le0_to_none', 'integer']
         },
-        'xgbreg': {
+        'xgboostreg': {
             'nthread': ['integer'],
             'n_estimators': ['integer'],
             'max_depth': ['integer'],

--- a/fedot/structural_analysis/operations_hp_sensitivity/params_bounds.json
+++ b/fedot/structural_analysis/operations_hp_sensitivity/params_bounds.json
@@ -141,7 +141,7 @@
       21
     ]
   },
-  "xgbreg": {
+  "xgboostreg": {
     "n_estimators": [
       80,
       110

--- a/test/unit/pipelines/test_operation_params.py
+++ b/test/unit/pipelines/test_operation_params.py
@@ -1,3 +1,4 @@
+from fedot.core.operations.hyperparameters_preprocessing import HyperparametersPreprocessor
 from fedot.core.operations.operation_parameters import OperationParameters
 
 
@@ -24,3 +25,20 @@ def test_params_keeper_get():
     assert a == 1
     assert b == 2
     assert d == 5
+
+
+def test_preprocessing_rules_defined_for_both_xgboost_operations():
+    """ Both halves of a model pair are expected to carry the same rules,
+    as is the case for lgbm/lgbmreg and catboost/catboostreg """
+    rules = HyperparametersPreprocessor.all_preprocessing_rules
+
+    assert rules.get('xgboostreg')
+    assert rules['xgboostreg'] == rules['xgboost']
+
+
+def test_integer_params_are_rounded_for_xgboostreg():
+    preprocessor = HyperparametersPreprocessor(operation_type='xgboostreg', n_samples_data=100)
+
+    corrected = preprocessor.correct({'max_depth': 3.7, 'n_estimators': 80.2})
+
+    assert corrected == {'max_depth': 4, 'n_estimators': 80}


### PR DESCRIPTION
Closes #1452

## What changed

`fedot/core/operations/hyperparameters_preprocessing.py:40` and `fedot/structural_analysis/operations_hp_sensitivity/params_bounds.json:144`: renamed the `xgbreg` key to `xgboostreg`. Values are untouched in both files.

`test/unit/pipelines/test_operation_params.py`: two tests for `HyperparametersPreprocessor`, which previously had none.

3 files changed, +20/-2.

## Why

`xgbreg` was renamed to `xgboostreg` in #1209 (`80eba8ef`). Both files kept the old key, so the entries they hold are unreachable and `xgboostreg` has neither.

### Hyperparameter preprocessing

`HyperparametersPreprocessor` runs on every operation fit (`operation.py:45`) and looks rules up by exact operation name. `xgboostreg` therefore gets an empty rule set, while every other boosting operation gets one.

The file pairs classifier and regressor consistently — `lgbm`/`lgbmreg` and `catboost`/`catboostreg` each carry identical rules. `xgboost`/`xgbreg` were such a pair too: the two blocks are byte-identical today. The rename left one half without a name.

The rules coerce `nthread`, `n_estimators`, `max_depth`, `max_leaves` and `max_bin` to integers. Some of those parameters no longer appear in `xgboostreg`'s defaults or search space, but `correct()` iterates over the parameters it is given rather than over the rules, so a rule for an absent parameter is a no-op. Whether the set is still current is a separate question, and it applies equally to `xgboost` — so I left the values alone rather than revising one half of the pair and re-splitting it.

`FedotXGBoostImplementation.check_and_update_params` validates `early_stopping_rounds`, `use_eval_set`, `booster` and `enable_categorical`; it does not do the rounding above.

### Sensitivity analysis bounds

Here the stale key is not merely unreachable — it raises. `OneOperationProblem.__init__` fetches bounds with `.get()` and immediately calls `len()` on the result:

```
>>> OneOperationProblem(['xgboostreg'])
TypeError: object of type 'NoneType' has no len()

>>> OneOperationProblem(['xgboost']).num_vars
5
```

After the rename, `xgboostreg` returns 5 parameters like its classifier counterpart.

### On the two subsystems

They are not duplicates of each other and this PR does not treat them as such: `params_bounds.json` defines ranges to sample from during sensitivity analysis, while `HyperparametersPreprocessor` coerces values on the way into a fit. They only share a symptom.

Two things I could not settle from the code, and would rather flag than guess:

1. In `params_bounds.json` the `xgbreg` block is **not** identical to `xgboost` — the ranges are wider for `n_estimators`, `max_depth` and `learning_rate`. That may be a deliberate choice for regression, or drift from an edit that touched one block only. Either reading argues for the rename: if the ranges are intentional, they are currently unreachable; if they are drift, the rename is still the first step and reconciling the values would be a separate decision. So the values are left as they are.

2. `Problem.INTEGER_PARAMS` (`problem.py:21`) duplicates, by name and without operation scoping, what the `'integer'` rules express in `HyperparametersPreprocessor`. If the two are meant to stay independent, that is worth stating somewhere explicit — right now nothing in the code says which one owns type coercion, which is part of why this key could go stale in two places at once and be missed twice.

I read both as oversights of the rename rather than intent, but the call is yours.

Worth noting: #1343 (`eae485e1`, *preprocessing hotfixes*, 2025-03-28) touched **both** of these files after the rename and left `xgbreg` in each.

The documentation already uses the new name — `docs/source/introduction/fedot_features/automation_features.rst` lists `xgboostreg` mapped to `xgboost.XGBRegressor` — so this brings the code in line with what is documented.

## Tests

`HyperparametersPreprocessor` had no test coverage. Added two, in the file that already covers `OperationParameters` from the same package:

- `test_preprocessing_rules_defined_for_both_xgboost_operations` — `xgboostreg` has rules and they match `xgboost`, the same invariant that holds for the lgbm and catboost pairs. Written against the pairing rather than against specific parameter names, so it survives a future revision of the rule set.
- `test_integer_params_are_rounded_for_xgboostreg` — `{'max_depth': 3.7, 'n_estimators': 80.2}` becomes `{'max_depth': 4, 'n_estimators': 80}`.

Both fail on master and pass with this change.

The `params_bounds.json` half is not covered: the sensitivity analysis module has no tests at all, and adding a harness for it is out of scope here. It is verified by the interpreter session quoted above.

## Verification

```
python -m pytest test/unit -q
    654 passed, 1718 warnings in 249.00s (0:04:08)
flake8 --max-line-length=120 fedot/core/operations/hyperparameters_preprocessing.py test/unit/pipelines/test_operation_params.py
    no output
python -m json.tool fedot/structural_analysis/operations_hp_sensitivity/params_bounds.json > /dev/null
    ok
grep -rn "xgbreg" --include=*.py --include=*.json fedot/
    only the four lines removed by #1453, which this branch does not include
```

Two of the 654 are the tests added here; the other five came with #1447-#1449, which landed after PR #1453 was opened.

Environment: Python 3.10.21, Linux (WSL2), editable install. Branch based on `5aa1a950`.

