### PR TITLE
fix: do not fail the fit when the cache DB is locked by a parallel worker

### DIFF
--- a/fedot/core/caching/base_cache.py
+++ b/fedot/core/caching/base_cache.py
@@ -1,3 +1,4 @@
+import sqlite3
 from typing import Union
 
 from golem.core.log import default_log
@@ -6,6 +7,15 @@ from golem.utilities.singleton_meta import SingletonMeta
 from fedot.core.caching.operations_cache_db import OperationsCacheDB
 from fedot.core.caching.preprocessing_cache_db import PreprocessingCacheDB
 from fedot.core.caching.predictions_cache_db import PredictionsCacheDB
+
+#  Sqlite failures caused by the environment instead of a bug in the caching code: a full disk, or a write lock
+#  held by another process sharing the same cache file (sqlite reports SQLITE_BUSY as 'database is locked'
+#  and SQLITE_LOCKED as 'database table is locked').
+_EXPECTED_DB_ERROR_REASONS = ('disk is full', 'locked', 'busy')
+
+
+def _is_expected_db_error(ex: BaseException) -> bool:
+    return isinstance(ex, sqlite3.Error) and any(reason in str(ex) for reason in _EXPECTED_DB_ERROR_REASONS)
 
 
 class BaseCache(metaclass=SingletonMeta):
@@ -27,11 +37,30 @@ class BaseCache(metaclass=SingletonMeta):
         if self._db.use_stats:
             #  Result order corresponds to the order in self.db._effectiveness_keys
             eff_dct = {}
-            returned_eff = self._db.get_effectiveness()
+            try:
+                returned_eff = self._db.get_effectiveness()
+            except Exception as ex:
+                self._handle_db_error(ex, 'Cache effectiveness can not be estimated')
+                return eff_dct
             for key, hit, total in zip(self._db.get_effectiveness_keys()[::2], returned_eff[::2], returned_eff[1::2]):
                 key = key.split('_')[0]
                 eff_dct[key] = round(hit / total, 3) if total else 0.
             return eff_dct
+
+    def _handle_db_error(self, ex: Exception, msg: str, level: str = 'warning'):
+        """
+        Reports a cache operation that could not be performed. Since the cache is an optimization, environment-caused
+        sqlite failures are only logged and leave the caller with a cache miss; anything else is treated as a bug
+        and is raised in a test session as usual.
+
+        :param ex: exception the cache DB has failed with
+        :param msg: description of the operation that was not performed
+        :param level: logging level for the errors considered unexpected
+        """
+        if _is_expected_db_error(ex):
+            self.log.warning(msg, exc_info=ex)
+        else:
+            self.log.log_or_raise(level, ValueError(msg))
 
     def reset(self, full_clean=False):
         """

--- a/fedot/core/caching/base_cache_db.py
+++ b/fedot/core/caching/base_cache_db.py
@@ -8,6 +8,10 @@ import psutil
 
 from fedot.core.utils import default_fedot_data_dir
 
+#  Seconds to wait for a write lock before giving up. Parallel workers share a single cache file, so the sqlite
+#  default of 5 seconds is not always enough for a big prediction blob to be written by a neighbour process.
+DB_LOCK_TIMEOUT = 15
+
 
 class BaseCacheDB:
     """
@@ -39,12 +43,18 @@ class BaseCacheDB:
         self._effectiveness_keys = stats_keys
         self._init_eff()
 
+    def connect(self) -> sqlite3.Connection:
+        """
+        Opens a connection to the cache DB, waiting `DB_LOCK_TIMEOUT` for a lock held by a parallel worker.
+        """
+        return sqlite3.connect(self.db_path, timeout=DB_LOCK_TIMEOUT)
+
     def get_effectiveness(self) -> Optional[Tuple[int, int, int, int]]:
         """
         Returns effectiveness of the cache in case of enabled `use_stats`, None instead.
         """
         if self.use_stats:
-            with closing(sqlite3.connect(self.db_path)) as conn:
+            with closing(self.connect()) as conn:
                 with conn:
                     cur = conn.cursor()
                     cur.execute(f'SELECT {",".join(self._effectiveness_keys)} FROM {self._eff_table};')
@@ -60,7 +70,7 @@ class BaseCacheDB:
         """
         Drops all scores from working table and resets efficiency table values to zero.
         """
-        with closing(sqlite3.connect(self.db_path)) as conn:
+        with closing(self.connect()) as conn:
             with conn:
                 cur = conn.cursor()
                 if self.use_stats:
@@ -75,7 +85,7 @@ class BaseCacheDB:
         Initializes effectiveness table.
         """
         if self.use_stats:
-            with closing(sqlite3.connect(self.db_path)) as conn:
+            with closing(self.connect()) as conn:
                 with conn:
                     cur = conn.cursor()
                     eff_type = ' INTEGER DEFAULT 0'
@@ -133,7 +143,7 @@ class BaseCacheDB:
         cur.execute(f'DELETE FROM {self._main_table};')
 
     def __len__(self):
-        with closing(sqlite3.connect(self.db_path)) as conn:
+        with closing(self.connect()) as conn:
             with conn:
                 cur = conn.cursor()
                 cur.execute(f'SELECT id FROM {self._main_table};')

--- a/fedot/core/caching/operations_cache.py
+++ b/fedot/core/caching/operations_cache.py
@@ -1,4 +1,3 @@
-import sqlite3
 from typing import List, Optional, TYPE_CHECKING, Union
 
 from golem.utilities.data_structures import ensure_wrapped_in_sequence
@@ -35,12 +34,7 @@ class OperationsCache(BaseCache):
             ]
             self._db.add_operations(mapped)
         except Exception as ex:
-            exc_is_expected = (isinstance(ex, sqlite3.DatabaseError) and 'disk is full' in str(ex))
-            msg = 'Nodes can not be saved'
-            if exc_is_expected:
-                self.log.warning(msg, exc_info=ex)
-            else:
-                self.log.log_or_raise('warning', ValueError(msg))
+            self._handle_db_error(ex, 'Nodes can not be saved')
 
     def save_pipeline(self, pipeline: 'Pipeline', fold_id: Optional[int] = None):
         """
@@ -65,8 +59,8 @@ class OperationsCache(BaseCache):
                     nodes_lst[idx].fitted_operation = cached_op
                 else:
                     nodes_lst[idx].fitted_operation = None
-        except Exception:
-            self.log.log_or_raise('info', ValueError('Cache can not be loaded.'))
+        except Exception as ex:
+            self._handle_db_error(ex, 'Cache can not be loaded.', level='info')
 
     def try_load_into_pipeline(self, pipeline: 'Pipeline', fold_id: Optional[int] = None):
         """

--- a/fedot/core/caching/operations_cache_db.py
+++ b/fedot/core/caching/operations_cache_db.py
@@ -54,7 +54,7 @@ class OperationsCacheDB(BaseCacheDB):
 
         :return retrieved: list of operations taken from DB table with None where it wasn't present
         """
-        with closing(sqlite3.connect(self.db_path)) as conn:
+        with closing(self.connect()) as conn:
             with conn:
                 cur = conn.cursor()
                 tmp_name = self._create_temp_for_ordered_select(cur, uids)
@@ -80,7 +80,7 @@ class OperationsCacheDB(BaseCacheDB):
 
         :param uid_val_lst: list of pairs (uid -> operation) to be saved
         """
-        with closing(sqlite3.connect(self.db_path)) as conn:
+        with closing(self.connect()) as conn:
             with conn:
                 cur = conn.cursor()
                 pickled = []
@@ -100,7 +100,7 @@ class OperationsCacheDB(BaseCacheDB):
         """
         Initializes DB working table.
         """
-        with closing(sqlite3.connect(self.db_path)) as conn:
+        with closing(self.connect()) as conn:
             with conn:
                 cur = conn.cursor()
                 cur.execute((

--- a/fedot/core/caching/predictions_cache.py
+++ b/fedot/core/caching/predictions_cache.py
@@ -43,9 +43,16 @@ class PredictionsCache(BaseCache):
 
     def _save_prediction(self, uid: str, outputData: OutputData):
         self.log.debug(f"--- SAVE prediction cache: {uid}")
-        self._db.add_prediction(uid, outputData)
+        try:
+            self._db.add_prediction(uid, outputData)
+        except Exception as ex:
+            self._handle_db_error(ex, 'Prediction can not be saved')
 
     def _load_prediction(self, uid: str):
-        outputData = self._db.get_prediction(uid)
+        try:
+            outputData = self._db.get_prediction(uid)
+        except Exception as ex:
+            self._handle_db_error(ex, 'Prediction can not be loaded')
+            return None
         self.log.debug(f"--- {'MISS' if outputData is None else 'HIT'} prediction cache: {uid}")
         return outputData

--- a/fedot/core/caching/predictions_cache_db.py
+++ b/fedot/core/caching/predictions_cache_db.py
@@ -50,7 +50,7 @@ class PredictionsCacheDB(BaseCacheDB):
         """
         Stores predicted `outputData` in binary format in a SQL table.
         """
-        with closing(sqlite3.connect(self.db_path)) as conn:
+        with closing(self.connect()) as conn:
             with conn:
                 cur = conn.cursor()
                 pickled_data = sqlite3.Binary(pickle.dumps(outputData, pickle.HIGHEST_PROTOCOL))
@@ -60,7 +60,7 @@ class PredictionsCacheDB(BaseCacheDB):
         """
         Retrieves the predicted `outputData` from binary format in a SQL table.
         """
-        with closing(sqlite3.connect(self.db_path)) as conn:
+        with closing(self.connect()) as conn:
             with conn:
                 cur = conn.cursor()
                 query = f"SELECT id, prediction FROM {self._main_table} WHERE id = ?"
@@ -81,7 +81,7 @@ class PredictionsCacheDB(BaseCacheDB):
         Retrieves statistics for all non-zero prediction cache entries.
         """
         if self.use_stats:
-            with closing(sqlite3.connect(self.db_path)) as conn:
+            with closing(self.connect()) as conn:
                 with conn:
                     cur = conn.cursor()
                     query = "SELECT id, retrieve_count FROM stats;"
@@ -99,7 +99,7 @@ class PredictionsCacheDB(BaseCacheDB):
         Initializes the database statistics table.
         """
         if self.use_stats:
-            with closing(sqlite3.connect(self.db_path)) as conn:
+            with closing(self.connect()) as conn:
                 with conn:
                     cur = conn.cursor()
                     cur.execute("PRAGMA journal_mode=WAL;")
@@ -109,7 +109,7 @@ class PredictionsCacheDB(BaseCacheDB):
         """
         Initializes the main database working table.
         """
-        with closing(sqlite3.connect(self.db_path)) as conn:
+        with closing(self.connect()) as conn:
             with conn:
                 cur = conn.cursor()
                 cur.execute("PRAGMA journal_mode=WAL;")

--- a/fedot/core/caching/preprocessing_cache.py
+++ b/fedot/core/caching/preprocessing_cache.py
@@ -30,8 +30,8 @@ class PreprocessingCache(BaseCache):
             processors = self._db.get_preprocessor(structural_id)
             if processors:
                 pipeline.encoder, pipeline.imputer = processors
-        except Exception:
-            self.log.log_or_raise('warning', ValueError('Preprocessor search error'))
+        except Exception as ex:
+            self._handle_db_error(ex, 'Preprocessor search error')
 
     def add_preprocessor(self, pipeline: 'Pipeline', fold_id: Optional[Union[int, None]] = None):
         """
@@ -40,8 +40,11 @@ class PreprocessingCache(BaseCache):
         :param pipeline: pipeline with preprocessor to add
         :param fold_id: number of fold
         """
-        structural_id = _get_db_uid(pipeline, fold_id)
-        self._db.add_preprocessor(structural_id, pipeline.preprocessor)
+        try:
+            structural_id = _get_db_uid(pipeline, fold_id)
+            self._db.add_preprocessor(structural_id, pipeline.preprocessor)
+        except Exception as ex:
+            self._handle_db_error(ex, 'Preprocessor can not be saved')
 
 
 def _get_db_uid(pipeline: 'Pipeline', fold_id: Union[int, None]) -> str:

--- a/fedot/core/caching/preprocessing_cache_db.py
+++ b/fedot/core/caching/preprocessing_cache_db.py
@@ -36,7 +36,7 @@ class PreprocessingCacheDB(BaseCacheDB):
 
         :return matched: pair of data processors (encoder, imputer) or None
         """
-        with closing(sqlite3.connect(self.db_path)) as conn:
+        with closing(self.connect()) as conn:
             with conn:
                 cur = conn.cursor()
                 cur.execute(f'SELECT encoder, imputer FROM {self._main_table} WHERE id = ?;', [uid])
@@ -58,7 +58,7 @@ class PreprocessingCacheDB(BaseCacheDB):
         :param uid: unique preprocessor identificator
         :param value: the preprocessor itself
         """
-        with closing(sqlite3.connect(self.db_path)) as conn:
+        with closing(self.connect()) as conn:
             with conn:
                 cur = conn.cursor()
                 pickled_encoder = sqlite3.Binary(pickle.dumps(value.features_encoders, pickle.HIGHEST_PROTOCOL))
@@ -70,7 +70,7 @@ class PreprocessingCacheDB(BaseCacheDB):
         """
         Initializes DB working table.
         """
-        with closing(sqlite3.connect(self.db_path)) as conn:
+        with closing(self.connect()) as conn:
             with conn:
                 cur = conn.cursor()
                 cur.execute((

--- a/test/unit/cache/test_predictions_cache.py
+++ b/test/unit/cache/test_predictions_cache.py
@@ -1,4 +1,5 @@
 import os
+import sqlite3
 
 import numpy as np
 import pytest
@@ -125,6 +126,45 @@ def test_uid_generation_variants(predictions_cache: PredictionsCache, output_tab
         result = predictions_cache.load_node_prediction(**case["params"])
         assert result is not None
         assert isinstance(result, OutputData)
+
+
+def test_locked_db_is_treated_as_cache_miss(predictions_cache: PredictionsCache, output_table_1d: OutputData,
+                                            monkeypatch):
+    """Test that a cache file locked by a parallel worker leaves the caller with a miss instead of an error"""
+    def raise_lock_error(*args, **kwargs):
+        raise sqlite3.OperationalError('database is locked')
+
+    monkeypatch.setattr(predictions_cache._db, 'add_prediction', raise_lock_error)
+    monkeypatch.setattr(predictions_cache._db, 'get_prediction', raise_lock_error)
+
+    predictions_cache.save_node_prediction(
+        descriptive_id="locked_node",
+        output_mode="default",
+        fold_id=0,
+        outputData=output_table_1d
+    )
+    result = predictions_cache.load_node_prediction(
+        descriptive_id="locked_node",
+        output_mode="default",
+        fold_id=0
+    )
+
+    assert result is None
+
+
+def test_unexpected_db_error_is_not_suppressed(predictions_cache: PredictionsCache, monkeypatch):
+    """Test that errors other than the environment-caused ones are still reported"""
+    def raise_unexpected_error(*args, **kwargs):
+        raise sqlite3.OperationalError('no such table: predictions')
+
+    monkeypatch.setattr(predictions_cache._db, 'get_prediction', raise_unexpected_error)
+
+    with pytest.raises(ValueError, match='Prediction can not be loaded'):
+        predictions_cache.load_node_prediction(
+            descriptive_id="broken_node",
+            output_mode="default",
+            fold_id=0
+        )
 
 
 def test_fit_vs_pred_type_handling(predictions_cache: PredictionsCache, output_table_1d: OutputData):

--- a/test/unit/cache/test_predictions_cache_db.py
+++ b/test/unit/cache/test_predictions_cache_db.py
@@ -3,6 +3,7 @@ import sqlite3
 from contextlib import closing
 from typing import List, Tuple
 
+from fedot.core.caching.base_cache_db import DB_LOCK_TIMEOUT
 from fedot.core.caching.predictions_cache_db import PredictionsCacheDB
 
 
@@ -32,6 +33,14 @@ def test_table_creation(tmp_cache: PredictionsCacheDB) -> None:
 
         cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='stats';")
         assert cursor.fetchone() is not None, "Stats table 'stats' not created."
+
+
+def test_connection_waits_for_lock(tmp_cache: PredictionsCacheDB) -> None:
+    """Test that connections are given time to outlive a lock taken by a parallel worker."""
+    with closing(tmp_cache.connect()) as conn:
+        busy_timeout = conn.execute('PRAGMA busy_timeout;').fetchone()[0]
+
+    assert busy_timeout == DB_LOCK_TIMEOUT * 1000, "Busy timeout is left at the sqlite default."
 
 
 def test_add_and_get_prediction(tmp_cache: PredictionsCacheDB) -> None:

--- a/test/unit/pipelines/test_pipeline_node_factory.py
+++ b/test/unit/pipelines/test_pipeline_node_factory.py
@@ -97,6 +97,7 @@ def test_advisor_accepts_only_models_as_sink():
     assert not advisor.can_be_sink(OptNode(content={'name': 'scaling'}))
     assert not advisor.can_be_sink(OptNode(content={'name': 'pca'}))
 
+
 def test_change_node_proposes_operations_excluded_by_default_tags():
     """An explicit list of operations must reach node replacement even for
     operations the default repository tag filter hides (qda, mlp, dt)."""
@@ -125,4 +126,3 @@ def test_from_available_operations_keeps_the_list_verbatim():
 
     assert set(repository.get_operations(is_primary=True)) == set(operations)
     assert set(repository.get_operations(is_primary=False)) == set(operations)
-


### PR DESCRIPTION
This is a bug fix.

## Summary

A cache is an optimization, so its unavailability should cost a recomputation, not a pipeline.

`BaseCache._handle_db_error` now separates sqlite failures caused by the environment (a full disk, or a lock held by a neighbour process) from genuine bugs. The former are logged and leave the caller with a cache miss; the latter keep going through `log_or_raise` exactly as before, so real errors still surface in tests. This generalizes the inline `'disk is full'` check that `OperationsCache.save_nodes` already had.

The handler is wired into the places reachable from a parallel fit. `PredictionsCache._load_prediction` and `_save_prediction` are the path from the traceback below; these called `self._db` unguarded, and a failed load now returns `None`, which `operation.py` already treats as a miss and recomputes. `BaseCache.effectiveness_ratio` is invoked from `data_objective_eval.py:101` in every worker on every evaluation, so it queries the shared file constantly, and was unguarded too. `PreprocessingCache.add_preprocessor` was not wrapped at all. `OperationsCache` and `PreprocessingCache.try_load_preprocessor` are switched over to the shared handler.

Additionally, `BaseCacheDB.connect()` applies `DB_LOCK_TIMEOUT = 15` seconds instead of the sqlite default of 5, so that most contention is resolved by waiting rather than by throwing away a cached node. All cache DB classes go through it, which also removes the fourteen copies of `sqlite3.connect(self.db_path)`.

### Tests

Three new unit tests in `test/unit/cache`: a locked DB degrades to a cache miss instead of raising; an error that is not environment-caused (`no such table`) still surfaces as `ValueError`; connections really carry the raised busy timeout, checked via `PRAGMA busy_timeout`.

`test/unit/cache`, `test/unit/pipelines/test_node_cache.py` and the previously failing `test/integration/cache/test_cache_api.py` pass locally.

## Context

The scheduled `Integration` workflow failed on Python 3.9 in [run 32371491199](https://github.com/aimclub/FEDOT/actions/runs/32371491199) with `sqlite3.OperationalError: database is locked` in `test_cache_api[ts_forecasting-rmse]`.

It is not a regression: the same commit (`5aa1a95`) passed the day before, and the 3.10 job of the failing run was green. The failure is a race.

`PredictionsCache` is created in the main process, so its DB file name is fixed to the parent pid, and the object is then pickled into the loky workers, so all of them write to one sqlite file (`n_jobs: 4` on the runner). With `use_stats=True`, which `DEFAULT_TESTS_CACHE_API_PARAMS` sets, every cache read also becomes a write: `get_prediction` follows its SELECT with an `UPDATE effectiveness ...` and an upsert into `stats`. When a worker loses the race for the write lock, `sqlite3.OperationalError` propagates out of `PredictionsCache`, where nothing catches it, into `data_objective_eval.py`. There it is caught at line 70 but re-raised at line 77 because `is_test_session()` is true, which kills the whole `Fedot.fit`.

Outside a test session the same error is not fatal, but it still silently drops the candidate pipeline from the population, for what is only a failed cache lookup.