### PR TITLE
fix: handle LinAlgError in RANSAC

### DIFF
--- a/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_filters.py
+++ b/fedot/core/operations/evaluation/operation_implementations/data_operations/sklearn_filters.py
@@ -86,7 +86,8 @@ class RegRANSACImplementation(FilterImplementation):
                 self.operation.fit(input_data.features, input_data.target.squeeze())
                 if self.operation.inlier_mask_.mean() >= self.min_inliers_ratio:
                     return self.operation
-            except ValueError:
+            # LinAlgError does not inherit from ValueError in every supported NumPy version.
+            except (ValueError, np.linalg.LinAlgError):
                 pass
 
             self.log.info(f"RANSAC: increased residual_threshold by {residual_threshold_step}")

--- a/test/unit/data_operations/test_data_operation_params.py
+++ b/test/unit/data_operations/test_data_operation_params.py
@@ -1,4 +1,5 @@
 from copy import copy
+from unittest.mock import Mock
 
 import numpy as np
 import pandas as pd
@@ -6,6 +7,9 @@ import pytest
 
 from fedot.core.data.data import InputData
 from fedot.core.data.data_split import train_test_data_setup
+from fedot.core.operations.evaluation.operation_implementations.data_operations.sklearn_filters import \
+    LinearRegRANSACImplementation
+from fedot.core.operations.operation_parameters import OperationParameters
 from fedot.core.pipelines.node import PipelineNode
 from fedot.core.pipelines.pipeline import Pipeline
 from fedot.core.repository.dataset_types import DataTypesEnum
@@ -80,6 +84,25 @@ def test_ransac_with_invalid_params_fit_correctly():
 
     assert ransac_pipeline.is_fitted
     assert predicted is not None
+
+
+def test_ransac_handles_linear_algebra_error():
+    """RANSAC should fall back to unfiltered data when its inner estimator cannot fit."""
+    data = InputData(idx=np.arange(5),
+                     features=np.arange(5).reshape(-1, 1),
+                     target=np.arange(5),
+                     task=Task(TaskTypesEnum.regression),
+                     data_type=DataTypesEnum.table)
+    implementation = LinearRegRANSACImplementation(OperationParameters(residual_threshold=0.1))
+    implementation.operation.fit = Mock(side_effect=np.linalg.LinAlgError('SVD did not converge'))
+
+    fitted_operation = implementation.fit(data)
+    transformed_data = implementation.transform_for_fit(data)
+
+    assert fitted_operation is implementation.operation
+    assert implementation.operation.fit.call_count == implementation.max_iter
+    assert implementation.operation.inlier_mask_ is None
+    np.testing.assert_array_equal(transformed_data.predict, data.features)
 
 
 def test_params_filter_with_non_default():


### PR DESCRIPTION
## Summary

- handle `numpy.linalg.LinAlgError` raised while fitting the RANSAC inner estimator
- preserve the existing fallback to unfiltered data after unsuccessful fitting attempts
- add regression coverage for NumPy versions where `LinAlgError` is not a `ValueError`

## Testing

- `pytest -q test/unit/data_operations/test_data_operation_params.py` - 9 passed
- `pytest -q -s test/integration/real_applications/test_examples.py::test_api_ts_forecasting_example` - 1 passed (10 sequential AutoML runs)