### PR TITLE
test: stabilize initial assumption integration check

### DIFF
--- a/test/integration/api/test_api_utils.py
+++ b/test/integration/api/test_api_utils.py
@@ -54,7 +54,11 @@ def test_predefined_initial_assumption():
     available_operations = ['bernb', 'dt', 'knn', 'lda', 'qda', 'logit', 'rf', 'svc',
                             'scaling', 'normalization', 'pca', 'kernel_pca']
 
-    model = Fedot(problem='classification', timeout=1.0,
+    # Keep composition independent of runner load and shared caches: this test checks parameter preservation.
+    model = Fedot(problem='classification', timeout=None, num_of_generations=1,
+                  pop_size=2, cv_folds=2, with_tuning=False, n_jobs=1,
+                  use_operations_cache=False, use_preprocessing_cache=False,
+                  use_predictions_cache=False,
                   logging_level=logging.ERROR, available_operations=available_operations,
                   initial_assumption=initial_pipelines)
     old_params = deepcopy(model.params)


### PR DESCRIPTION
## Summary
- make the initial-assumption integration check independent of runner timing
- use one deterministic generation without tuning or multiprocessing
- disable caches that are unrelated to parameter-preservation assertions

## Root cause
The same master commit passed the scheduled integration matrix on September 9-11, then failed on Python 3.10 on September 12. Under runner load, fitting the initial pipeline took long enough for the timeout heuristic to skip composition. The test nevertheless assumed that optimization history had been produced and called `len()` on `history.initial_assumptions`, which was `None`.

## Verification
- targeted test passed three consecutive times on Python 3.10
- targeted test passed concurrently on Python 3.10, 3.11, 3.12, 3.13, and 3.14